### PR TITLE
Initialize children to undefined.

### DIFF
--- a/src/Alert.svelte
+++ b/src/Alert.svelte
@@ -5,7 +5,7 @@
 
   let className = '';
   export { className as class };
-  export let children;
+  export let children = undefined;
   export let color = 'success';
   export let closeClassName = '';
   export let closeAriaLabel = 'Close';

--- a/src/Badge.svelte
+++ b/src/Badge.svelte
@@ -4,7 +4,7 @@
 
   let className = '';
   export { className as class };
-  export let children;
+  export let children = undefined;
   export let color = 'secondary';
   export let href = undefined;
   export let pill = false;

--- a/src/Breadcrumb.svelte
+++ b/src/Breadcrumb.svelte
@@ -5,7 +5,7 @@
   let className = '';
   export { className as class };
   export let ariaLabel = 'breadcrumb';
-  export let children;
+  export let children = undefined;
   export let listClassName = '';
 
   const props = clean($$props);

--- a/src/BreadcrumbItem.svelte
+++ b/src/BreadcrumbItem.svelte
@@ -5,7 +5,7 @@
   let className = '';
   export { className as class };
   export let active = false;
-  export let children;
+  export let children = undefined;
 
   const props = clean($$props);
 

--- a/src/Button.svelte
+++ b/src/Button.svelte
@@ -6,7 +6,7 @@
   export { className as class };
   export let active = false;
   export let block = false;
-  export let children;
+  export let children = undefined;
   export let close = false;
   export let color = 'secondary';
   export let disabled = false;

--- a/src/ModalHeader.svelte
+++ b/src/ModalHeader.svelte
@@ -7,7 +7,7 @@
   export let toggle = undefined;
   export let closeAriaLabel = 'Close';
   export let charCode = 215;
-  export let children;
+  export let children = undefined;
 
   const props = clean($$props);
 


### PR DESCRIPTION
Avoids compiler error.
Related to #54 