### PR TITLE
Correct collapse fade

### DIFF
--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -15,7 +15,6 @@
   export let onExited = noop;
 
   const props = clean($$props);
-
   let _wasOpen = isOpen;
   $: classes = clsx(
     className,
@@ -23,17 +22,10 @@
     navbar && 'navbar-collapse',
   );
 
-  let windowWidth = window.innerWidth;
-
-  $: if (windowWidth >= 768 && navbar && _wasOpen === isOpen) {
-    _wasOpen = isOpen;
-    isOpen = true;
-  } else if (windowWidth < 768) {
-    isOpen = _wasOpen;
-  }
+  // TODO if navbar, then need to close when transitioning from md -> sm breakpoints.
+  // Can't hardcode 768, etc, as those can be diffrent in diffent themes.
+  // Needs to be breakpoint when navbar-toggler is display: block|none
 </script>
-
-<svelte:window bind:innerWidth="{windowWidth}" />
 
 {#if isOpen}
   <div

--- a/src/Fade.svelte
+++ b/src/Fade.svelte
@@ -8,32 +8,13 @@
   export let isOpen = false;
   let className = '';
   export { className as class };
-  export let navbar = false;
   export let onEntering = noop;
   export let onEntered = noop;
   export let onExiting = noop;
   export let onExited = noop;
 
   const props = clean($$props);
-
-  let _wasOpen = isOpen;
-  $: classes = clsx(
-    className,
-    // collapseClass,
-    navbar && 'navbar-collapse',
-  );
-
-  let windowWidth = window.innerWidth;
-
-  $: if (windowWidth >= 768 && navbar && _wasOpen === isOpen) {
-    _wasOpen = isOpen;
-    isOpen = true;
-  } else if (windowWidth < 768) {
-    isOpen = _wasOpen;
-  }
 </script>
-
-<svelte:window bind:innerWidth="{windowWidth}" />
 
 {#if isOpen}
   <div
@@ -47,7 +28,7 @@
     on:introend="{onEntered}"
     on:outrostart="{onExiting}"
     on:outroend="{onExited}"
-    class="{classes}"
+    class="{className}"
   >
     <slot />
   </div>


### PR DESCRIPTION
Correct Collapse on mobile:
Remove logic trying to close on md->sm transition, incorrect hardcoding of breakpoints.

Correct Fade on mobile, remove unused code copied from Collapse

Fixes #56 