### PR TITLE
Add on:submit event to Form

### DIFF
--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -11,6 +11,6 @@
   $: classes = clsx(className, inline ? 'form-inline' : false);
 </script>
 
-<form {...props} class={classes}>
+<form {...props} class={classes} on:submit>
   <slot />
 </form>


### PR DESCRIPTION
Currently, we're unable to use on:submit with the Form component because it is not defined in the <form> tag. I've added it to <form> so that it is exposed from the Form component.