### PR TITLE
compatibility with routers! Transition just local

### DIFF
--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -59,7 +59,7 @@
 
 {#if isOpen}
   <div
-    transition:slide
+    transition:slide|local
     on:introstart
     on:introend
     on:outrostart

--- a/src/Fade.svelte
+++ b/src/Fade.svelte
@@ -18,7 +18,7 @@
 {#if isOpen}
   <div
     {...props}
-    transition:fade
+    transition:fade|local
     on:introstart
     on:introend
     on:outrostart


### PR DESCRIPTION
When I use a router (for example svelte-routing) with svelte and want to change the page, the old page stays until all transitions are finished. If the transition is just local, the routing works without waiting.