### PR TITLE
DropdownItem: fix props spread

### DIFF
--- a/src/DropdownItem.svelte
+++ b/src/DropdownItem.svelte
@@ -47,7 +47,7 @@
     <slot />
   </div>
 {:else if href}
-  <a on:{...props} click on:click={handleItemClick} {href} class={classes}>
+  <a {...props} click on:click={handleItemClick} {href} class={classes}>
     <slot />
   </a>
 {:else}


### PR DESCRIPTION
The anchor tag in DropdownItem included `on:{...props}` instead of just `{...props}`, which I believe is a mistake because this is the only place in all the components that this is happening. Currently when we try to add a "target='_blank'", it is not working because the target attribute is not properly spreading within the anchor element.