### PR TITLE
Fix order of spreading props in Dropdown, Collapse and CustomInput

### DIFF
--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -59,6 +59,8 @@
 
 {#if isOpen}
   <div
+    {...props}
+    class={classes}
     transition:slide
     on:introstart
     on:introend
@@ -67,9 +69,7 @@
     on:introstart={onEntering}
     on:introend={onEntered}
     on:outrostart={onExiting}
-    on:outroend={onExited}
-    class={classes}
-    {...props}>
+    on:outroend={onExited}>
     <slot />
   </div>
 {/if}

--- a/src/CustomInput.svelte
+++ b/src/CustomInput.svelte
@@ -45,6 +45,7 @@
 
 {#if type === 'select'}
   <select
+    {...props}
     {id}
     class={combinedClasses}
     on:blur
@@ -54,13 +55,13 @@
     bind:value
     {name}
     {disabled}
-    {placeholder}
-    {...props}>
+    {placeholder}>
     <slot />
   </select>
 {:else if type === 'file'}
   <div class={customClass}>
     <input
+      {...props}
       {id}
       type="file"
       class={fileClasses}
@@ -70,8 +71,7 @@
       on:input
       {name}
       {disabled}
-      {placeholder}
-      {...props} />
+      {placeholder} />
     <label class="custom-file-label" for={labelHtmlFor}>
       {label || 'Choose file'}
     </label>
@@ -79,32 +79,33 @@
 {:else if type === 'switch' || type === 'checkbox'}
   <div class={wrapperClasses}>
     <input
+      {...props}
       {id}
       type="checkbox"
       class={customControlClasses}
       bind:checked
       {name}
       {disabled}
-      {placeholder}
-      {...props} />
+      {placeholder} />
     <label class="custom-control-label" for={labelHtmlFor}>{label}</label>
     <slot />
   </div>
 {:else if type === 'radio'}
   <div class={wrapperClasses}>
     <input
+      {...props}
       {id}
       type="radio"
       class={customControlClasses}
       {name}
       {disabled}
-      {placeholder}
-      {...props} />
+      {placeholder} />
     <label class="custom-control-label" for={labelHtmlFor}>{label}</label>
     <slot />
   </div>
 {:else}
   <input
+    {...props}
     {type}
     {id}
     class={combinedClasses}
@@ -114,6 +115,5 @@
     on:input
     {name}
     {disabled}
-    {placeholder}
-    {...props} />
+    {placeholder} />
 {/if}

--- a/src/Dropdown.svelte
+++ b/src/Dropdown.svelte
@@ -97,11 +97,11 @@
 </script>
 
 {#if nav}
-  <li class={classes} bind:this={component} {...props}>
+  <li {...props} class={classes} bind:this={component}>
     <slot />
   </li>
 {:else}
-  <div class={classes} bind:this={component} {...props}>
+  <div {...props} class={classes} bind:this={component}>
     <slot />
   </div>
 {/if}


### PR DESCRIPTION
Spread 'props' (i.e. `{...props}`) firstly (before any other attributes) since some of properties from them may override local ones
For example, `class` property from UncontrolledDropdown will override the same one from 'Dropdown'.
More information can be found here #143