### PR TITLE
Remove preventDefault from keydown event in Carousel

### DIFF
--- a/src/Carousel.svelte
+++ b/src/Carousel.svelte
@@ -85,7 +85,7 @@
   }
 </script>
 
-<svelte:window on:keydown|preventDefault={handleKeydown} />
+<svelte:window on:keydown={handleKeydown} />
 
 <div
   {...props}


### PR DESCRIPTION
Having preventDefault on the keydown event set to window object without checking for the target makes any other interactive element rendered next to Carousel entirely non-interactive as it traps the keydown. an example can be an input element.