### PR TITLE
Correct usage with svelte 3.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19811,9 +19811,9 @@
       }
     },
     "svelte": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.12.1.tgz",
-      "integrity": "sha512-t29WJNjHIqfrdMcVXqIyRfgLEaNz7MihKXTpb8qHlbzvf0WyOOIhIlwIGvl6ahJ9+9CLJwz0sjhFNAmPgo8BHg==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.24.0.tgz",
+      "integrity": "sha512-VFXom6EP2DK83kxy4ZlBbaZklSbZIrpNH3oNXlPYHJUuW4q1OuAr3ZoYbfIVTVYPDgrI7Yq0gQcOhDlAtO4qfw==",
       "dev": true
     },
     "svelte-dev-helper": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "rollup-plugin-terser": "^5.2.0",
     "sirv-cli": "^0.3.1",
     "standard-version": "^6.0.1",
-    "svelte": "^3.12.1",
+    "svelte": "^3.24.0",
     "svelte-loader": "^2.13.6",
     "svelte-preprocess": "^2.16.0",
     "wait-for-localhost-cli": "^1.1.0",

--- a/src/Alert.svelte
+++ b/src/Alert.svelte
@@ -1,7 +1,6 @@
 <script>
   import { fade as fadeTransition } from 'svelte/transition';
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -14,7 +13,6 @@
   export let fade = true;
   export let transition = { duration: fade ? 400 : 0 };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'alert', `alert-${color}`, {
     'alert-dismissible': toggle
@@ -24,7 +22,7 @@
 
 {#if isOpen}
   <div
-    {...props}
+    {...$$restProps}
     transition:fadeTransition={transition}
     class={classes}
     role="alert">

--- a/src/Badge.svelte
+++ b/src/Badge.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -9,7 +8,6 @@
   export let href = undefined;
   export let pill = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -20,7 +18,7 @@
 </script>
 
 {#if href}
-  <a {...props} {href} class={classes}>
+  <a {...$$restProps} {href} class={classes}>
     {#if children}
       {children}
     {:else}
@@ -28,7 +26,7 @@
     {/if}
   </a>
 {:else}
-  <span {...props} class={classes}>
+  <span {...$$restProps} class={classes}>
     {#if children}
       {children}
     {:else}

--- a/src/Breadcrumb.svelte
+++ b/src/Breadcrumb.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -8,12 +7,11 @@
   export let children = undefined;
   export let listClassName = '';
 
-  const props = clean($$props);
 
   $: listClasses = clsx('breadcrumb', listClassName);
 </script>
 
-<nav {...props} aria-label={ariaLabel} class={className}>
+<nav {...$$restProps} aria-label={ariaLabel} class={className}>
   <ol class={listClasses}>
     {#if children}
       {children}

--- a/src/BreadcrumbItem.svelte
+++ b/src/BreadcrumbItem.svelte
@@ -1,18 +1,16 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let active = false;
   export let children = undefined;
 
-  const props = clean($$props);
 
   $: classes = clsx(className, active ? 'active' : false, 'breadcrumb-item');
 </script>
 
-<li {...props} class={classes} aria-current={active ? 'page' : undefined}>
+<li {...$$restProps} class={classes} aria-current={active ? 'page' : undefined}>
   {#if children}
     {children}
   {:else}

--- a/src/Button.svelte
+++ b/src/Button.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -17,7 +16,6 @@
   export let style = '';
   export let value = '';
 
-  const props = clean($$props);
 
   $: ariaLabel = $$props['aria-label'];
 
@@ -36,7 +34,7 @@
 
 {#if href}
   <a
-    {...props}
+    {...$$restProps}
     {id}
     class={classes}
     {disabled}
@@ -52,7 +50,7 @@
   </a>
 {:else}
   <button
-    {...props}
+    {...$$restProps}
     {id}
     class={classes}
     {disabled}

--- a/src/ButtonDropdown.svelte
+++ b/src/ButtonDropdown.svelte
@@ -1,6 +1,5 @@
 <script>
   import Dropdown from './Dropdown.svelte';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -17,11 +16,10 @@
   export let size = '';
   export let toggle = undefined;
 
-  const props = clean($$props);
 </script>
 
 <Dropdown
-  {...props}
+  {...$$restProps}
   {group}
   class={className}
   {disabled}

--- a/src/ButtonGroup.svelte
+++ b/src/ButtonGroup.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -8,7 +7,6 @@
   export let size = '';
   export let vertical = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -17,6 +15,6 @@
   );
 </script>
 
-<div {...props} {id} class={classes}>
+<div {...$$restProps} {id} class={classes}>
   <slot />
 </div>

--- a/src/ButtonToolbar.svelte
+++ b/src/ButtonToolbar.svelte
@@ -1,16 +1,14 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let ariaLabel = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'btn-toolbar');
 </script>
 
-<div {...props} aria-label={ariaLabel} role="toolbar" class={classes}>
+<div {...$$restProps} aria-label={ariaLabel} role="toolbar" class={classes}>
   <slot />
 </div>

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -11,7 +10,6 @@
   export let outline = false;
   export let style = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -22,6 +20,6 @@
   );
 </script>
 
-<div {...props} {id} class={classes} on:click {style}>
+<div {...$$restProps} {id} class={classes} on:click {style}>
   <slot />
 </div>

--- a/src/CardBody.svelte
+++ b/src/CardBody.svelte
@@ -1,16 +1,14 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let id = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-body');
 </script>
 
-<div {...props} {id} class={classes}>
+<div {...$$restProps} {id} class={classes}>
   <slot />
 </div>

--- a/src/CardColumns.svelte
+++ b/src/CardColumns.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-columns');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/CardDeck.svelte
+++ b/src/CardDeck.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-deck');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/CardFooter.svelte
+++ b/src/CardFooter.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-footer');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/CardGroup.svelte
+++ b/src/CardGroup.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-group');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/CardHeader.svelte
+++ b/src/CardHeader.svelte
@@ -1,23 +1,21 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let id = '';
   export let tag = 'div';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-header');
 </script>
 
 {#if tag === 'h3'}
-  <h3 {...props} {id} class={classes} on:click>
+  <h3 {...$$restProps} {id} class={classes} on:click>
     <slot />
   </h3>
 {:else}
-  <div {...props} {id} class={classes} on:click>
+  <div {...$$restProps} {id} class={classes} on:click>
     <slot />
   </div>
 {/if}

--- a/src/CardImg.svelte
+++ b/src/CardImg.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -9,7 +8,6 @@
   export let src;
   export let alt = '';
 
-  const props = clean($$props);
 
   let classes = '';
   $: {
@@ -24,4 +22,4 @@
   }
 </script>
 
-<img {...props} class={classes} {src} {alt} />
+<img {...$$restProps} class={classes} {src} {alt} />

--- a/src/CardImgOverlay.svelte
+++ b/src/CardImgOverlay.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-img-overlay');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/CardLink.svelte
+++ b/src/CardLink.svelte
@@ -1,16 +1,14 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let href = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-link');
 </script>
 
-<a {...props} class={classes} {href}>
+<a {...$$restProps} class={classes} {href}>
   <slot />
 </a>

--- a/src/CardSubtitle.svelte
+++ b/src/CardSubtitle.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-subtitle');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/CardText.svelte
+++ b/src/CardText.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-text');
 </script>
 
-<p {...props} class={classes}>
+<p {...$$restProps} class={classes}>
   <slot />
 </p>

--- a/src/CardTitle.svelte
+++ b/src/CardTitle.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'card-title');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/Carousel.svelte
+++ b/src/Carousel.svelte
@@ -2,7 +2,6 @@
   import { onDestroy, onMount } from 'svelte';
   import clsx from 'clsx';
   import { getNewCarouselActiveIndex, browserEvent } from './utils';
-  import { clean } from './utils';
 
   let classes = '';
   let className = '';
@@ -18,7 +17,6 @@
   let _rideTimeoutId = false;
   let _removeVisibilityChangeListener = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'carousel', 'slide');
 
@@ -88,7 +86,7 @@
 <svelte:window on:keydown={handleKeydown} />
 
 <div
-  {...props}
+  {...$$restProps}
   {id}
   class={classes}
   {style}

--- a/src/CarouselCaption.svelte
+++ b/src/CarouselCaption.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let classes = '';
   let className = '';
@@ -9,12 +8,11 @@
   export let captionHeader = '';
   export let captionText = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'carousel-caption', 'd-none', 'd-md-block');
 </script>
 
-<div {...props} {id} class={classes}>
+<div {...$$restProps} {id} class={classes}>
   <h5>{captionHeader}</h5>
   <p>{captionText}</p>
   <slot />

--- a/src/CarouselControl.svelte
+++ b/src/CarouselControl.svelte
@@ -1,7 +1,6 @@
 <script>
   import clsx from 'clsx';
   import { getNewCarouselActiveIndex } from './utils';
-  import { clean } from './utils';
 
   let classes = '';
   let className = '';
@@ -14,7 +13,6 @@
   export let items = [];
   export let wrap = true;
 
-  const props = clean($$props);
 
   $: classes = clsx(`carousel-control-${direction}`, className);
 
@@ -42,7 +40,7 @@
 </script>
 
 <a
-  {...props}
+  {...$$restProps}
   {id}
   class={classes}
   role="button"

--- a/src/CarouselIndicators.svelte
+++ b/src/CarouselIndicators.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   let classes = '';
@@ -9,12 +8,11 @@
   export let activeIndex = 0;
   export let id = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'carousel-indicators');
 </script>
 
-<ol {...props} {id} class={classes}>
+<ol {...$$restProps} {id} class={classes}>
   {#each items as item, index}
     <li
       class:active={activeIndex === index}

--- a/src/CarouselItem.svelte
+++ b/src/CarouselItem.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let classes = '';
   let className = '';
@@ -9,13 +8,12 @@
   export let activeIndex = 0;
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'carousel-item');
 </script>
 
 <div
-  {...props}
+  {...$$restProps}
   {id}
   class="{classes} active"
   class:active={itemIndex === activeIndex}>

--- a/src/Col.svelte
+++ b/src/Col.svelte
@@ -1,12 +1,10 @@
 <script>
-  import { clean } from './utils';
   import { getColumnSizeClass, isObject } from './utils';
 
   let className = '';
   export { className as class };
   export let id = '';
 
-  const props = clean($$props);
 
   const colClasses = [];
   const widths = ['xs', 'sm', 'md', 'lg', 'xl'];
@@ -49,6 +47,6 @@
   }
 </script>
 
-<div {...props} {id} class={colClasses.join(' ')}>
+<div {...$$restProps} {id} class={colClasses.join(' ')}>
   <slot />
 </div>

--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   import { createEventDispatcher } from 'svelte';
   import { slide } from 'svelte/transition';
@@ -16,7 +15,6 @@
   export let onExited = noop;
   export let expand = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -59,7 +57,7 @@
 
 {#if isOpen}
   <div
-    {...props}
+    {...$$restProps}
     class={classes}
     transition:slide|local
     on:introstart

--- a/src/Container.svelte
+++ b/src/Container.svelte
@@ -1,17 +1,15 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let fluid = false;
   export let id = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, fluid ? 'container-fluid' : 'container');
 </script>
 
-<div {...props} {id} class={classes}>
+<div {...$$restProps} {id} class={classes}>
   <slot />
 </div>

--- a/src/CustomInput.svelte
+++ b/src/CustomInput.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -18,9 +17,6 @@
   export let placeholder = '';
   export let htmlFor = '';
   export { htmlFor as for };
-
-  // eslint-disable-next-line no-unused-vars
-  const { type: _omitType, ...props } = clean($$props);
 
   $: customClass = clsx(
     className,
@@ -45,7 +41,7 @@
 
 {#if type === 'select'}
   <select
-    {...props}
+    {...$$restProps}
     {id}
     class={combinedClasses}
     on:blur
@@ -61,7 +57,7 @@
 {:else if type === 'file'}
   <div class={customClass}>
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="file"
       class={fileClasses}
@@ -79,7 +75,7 @@
 {:else if type === 'switch' || type === 'checkbox'}
   <div class={wrapperClasses}>
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="checkbox"
       class={customControlClasses}
@@ -93,7 +89,7 @@
 {:else if type === 'radio'}
   <div class={wrapperClasses}>
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="radio"
       class={customControlClasses}
@@ -105,7 +101,7 @@
   </div>
 {:else}
   <input
-    {...props}
+    {...$$restProps}
     {type}
     {id}
     class={combinedClasses}

--- a/src/Dropdown.svelte
+++ b/src/Dropdown.svelte
@@ -1,7 +1,6 @@
 <script>
   import { setContext } from 'svelte';
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   import { createContext } from './DropdownContext';
 
@@ -22,7 +21,6 @@
   export let setActiveFromChild = false;
   export let dropup = false;
 
-  const props = clean($$props);
 
   const validDirections = ['up', 'down', 'left', 'right'];
 
@@ -97,11 +95,11 @@
 </script>
 
 {#if nav}
-  <li {...props} class={classes} bind:this={component}>
+  <li {...$$restProps} class={classes} bind:this={component}>
     <slot />
   </li>
 {:else}
-  <div {...props} class={classes} bind:this={component}>
+  <div {...$$restProps} class={classes} bind:this={component}>
     <slot />
   </div>
 {/if}

--- a/src/DropdownItem.svelte
+++ b/src/DropdownItem.svelte
@@ -1,7 +1,6 @@
 <script>
   import { getContext } from 'svelte';
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   const context = getContext('dropdownContext');
 
@@ -15,7 +14,6 @@
   export let toggle = true;
   export let href = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, {
     disabled,
@@ -38,20 +36,20 @@
 </script>
 
 {#if header}
-  <h6 {...props} on:click on:click={handleItemClick} class={classes}>
+  <h6 {...$$restProps} on:click on:click={handleItemClick} class={classes}>
     <slot />
   </h6>
 
 {:else if divider}
-  <div {...props} on:click on:click={handleItemClick} class={classes}>
+  <div {...$$restProps} on:click on:click={handleItemClick} class={classes}>
     <slot />
   </div>
 {:else if href}
-  <a {...props} click on:click={handleItemClick} {href} class={classes}>
+  <a {...$$restProps} click on:click={handleItemClick} {href} class={classes}>
     <slot />
   </a>
 {:else}
-  <button {...props} on:click on:click={handleItemClick} class={classes}>
+  <button {...$$restProps} on:click on:click={handleItemClick} class={classes}>
     <slot />
   </button>
 {/if}

--- a/src/DropdownMenu.svelte
+++ b/src/DropdownMenu.svelte
@@ -1,7 +1,6 @@
 <script>
   import { getContext } from 'svelte';
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   const context = getContext('dropdownContext');
 
@@ -9,7 +8,6 @@
   export { className as class };
   export let right = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'dropdown-menu', {
     'dropdown-menu-right': right,
@@ -17,6 +15,6 @@
   });
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/DropdownToggle.svelte
+++ b/src/DropdownToggle.svelte
@@ -1,7 +1,6 @@
 <script>
   import { getContext } from 'svelte';
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   import Button from './Button.svelte';
 
@@ -20,7 +19,6 @@
   export let tag = null;
   export let outline = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(className, {
     'dropdown-toggle': caret || split,
@@ -44,7 +42,7 @@
 
 {#if nav}
   <a
-    {...props}
+    {...$$restProps}
     on:click
     on:click={toggleButton}
     href="#nav"
@@ -56,7 +54,7 @@
   </a>
 {:else if tag === 'span'}
   <span
-    {...props}
+    {...$$restProps}
     on:click
     on:click={toggleButton}
     {ariaHaspopup}
@@ -69,7 +67,7 @@
   </span>
 {:else}
   <Button
-    {...props}
+    {...$$restProps}
     on:click
     on:click={toggleButton}
     {ariaHaspopup}

--- a/src/Fade.svelte
+++ b/src/Fade.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { clean } from './utils';
 
   import { fade } from 'svelte/transition';
   const noop = () => undefined;
@@ -12,12 +11,11 @@
   export let onExiting = noop;
   export let onExited = noop;
 
-  const props = clean($$props);
 </script>
 
 {#if isOpen}
   <div
-    {...props}
+    {...$$restProps}
     transition:fade|local
     on:introstart
     on:introend

--- a/src/Form.svelte
+++ b/src/Form.svelte
@@ -1,16 +1,14 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let inline = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(className, inline ? 'form-inline' : false);
 </script>
 
-<form {...props} class={classes} on:submit>
+<form {...$$restProps} class={classes} on:submit>
   <slot />
 </form>

--- a/src/FormFeedback.svelte
+++ b/src/FormFeedback.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -8,7 +7,6 @@
   export let tooltip = false;
   let classes;
 
-  const props = clean($$props);
 
   $: {
     const validMode = tooltip ? 'tooltip' : 'feedback';
@@ -20,6 +18,6 @@
   }
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/FormGroup.svelte
+++ b/src/FormGroup.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   export let className = '';
   export { className as class };
@@ -11,7 +10,6 @@
   export let id = '';
   export let tag = null;
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -23,11 +21,11 @@
 </script>
 
 {#if tag === 'fieldset'}
-  <fieldset {...props} {id} class={classes}>
+  <fieldset {...$$restProps} {id} class={classes}>
     <slot />
   </fieldset>
 {:else}
-  <div {...props} {id} class={classes}>
+  <div {...$$restProps} {id} class={classes}>
     <slot />
   </div>
 {/if}

--- a/src/FormText.svelte
+++ b/src/FormText.svelte
@@ -1,13 +1,11 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let inline = false;
   export let color = 'muted';
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -16,6 +14,6 @@
   );
 </script>
 
-<small {...props} class={classes}>
+<small {...$$restProps} class={classes}>
   <slot />
 </small>

--- a/src/Input.svelte
+++ b/src/Input.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -22,9 +21,6 @@
   export let name = '';
   export let placeholder = '';
   export let disabled = false;
-
-  // eslint-disable-next-line no-unused-vars
-  const { type: _omitType, color: _omitColor, ...props } = clean($$props);
 
   let classes;
   let tag;
@@ -86,7 +82,7 @@
 {#if tag === 'input'}
   {#if type === 'text'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="text"
       on:blur
@@ -104,7 +100,7 @@
       {placeholder} />
   {:else if type === 'password'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="password"
       on:blur
@@ -122,7 +118,7 @@
       {placeholder} />
   {:else if type === 'email'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="email"
       on:blur
@@ -140,7 +136,7 @@
       {placeholder} />
   {:else if type === 'file'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="file"
       on:blur
@@ -158,7 +154,7 @@
       {placeholder} />
   {:else if type === 'checkbox'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="checkbox"
       on:blur
@@ -177,7 +173,7 @@
       {placeholder} />
   {:else if type === 'radio'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="radio"
       on:blur
@@ -195,7 +191,7 @@
       {placeholder} />
   {:else if type === 'url'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="url"
       on:blur
@@ -213,7 +209,7 @@
       {placeholder} />
   {:else if type === 'number'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="number"
       on:blur
@@ -231,7 +227,7 @@
       {placeholder} />
   {:else if type === 'date'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="date"
       on:blur
@@ -249,7 +245,7 @@
       {placeholder} />
   {:else if type === 'time'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="time"
       on:blur
@@ -267,7 +263,7 @@
       {placeholder} />
   {:else if type === 'datetime'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="datetime"
       on:blur
@@ -285,7 +281,7 @@
       {placeholder} />
   {:else if type === 'color'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="color"
       on:blur
@@ -303,7 +299,7 @@
       {placeholder} />
   {:else if type === 'range'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="range"
       on:blur
@@ -321,7 +317,7 @@
       {placeholder} />
   {:else if type === 'search'}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       type="search"
       on:blur
@@ -339,7 +335,7 @@
       {placeholder} />
   {:else}
     <input
-      {...props}
+      {...$$restProps}
       {id}
       {type}
       on:blur
@@ -359,7 +355,7 @@
 
 {:else if tag === 'textarea'}
   <textarea
-    {...props}
+    {...$$restProps}
     {id}
     class={classes}
     on:blur
@@ -375,7 +371,7 @@
 
 {:else if tag === 'select' && !multiple}
   <select
-    {...props}
+    {...$$restProps}
     {id}
     class={classes}
     on:blur
@@ -388,9 +384,9 @@
     <slot />
   </select>
 
-{:else if tag === 'select' && multiple}
+<!-- {:else if tag === 'select' && multiple}
   <select
-    {...props}
+    {...$$restProps}
     {id}
     multiple
     class={classes}
@@ -402,5 +398,5 @@
     {name}
     {disabled}>
     <slot />
-  </select>
+  </select> -->
 {/if}

--- a/src/InputGroup.svelte
+++ b/src/InputGroup.svelte
@@ -1,12 +1,10 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let size = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -15,6 +13,6 @@
   );
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/InputGroupAddon.svelte
+++ b/src/InputGroupAddon.svelte
@@ -1,12 +1,10 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let addonType;
 
-  const props = clean($$props);
 
   if (['prepend', 'append'].indexOf(addonType) === -1) {
     throw new Error(
@@ -17,6 +15,6 @@
   $: classes = clsx(className, `input-group-${addonType}`);
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/InputGroupButtonDropdown.svelte
+++ b/src/InputGroupButtonDropdown.svelte
@@ -1,6 +1,5 @@
 <script>
   import Dropdown from './Dropdown.svelte';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -8,7 +7,6 @@
   export let toggle;
   export let isOpen;
 
-  const props = clean($$props);
 
   if (['prepend', 'append'].indexOf(addonType) === -1) {
     throw new Error(
@@ -17,6 +15,6 @@
   }
 </script>
 
-<Dropdown {...props} class={className} {addonType} {toggle} {isOpen}>
+<Dropdown {...$$restProps} class={className} {addonType} {toggle} {isOpen}>
   <slot />
 </Dropdown>

--- a/src/InputGroupText.svelte
+++ b/src/InputGroupText.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'input-group-text');
 </script>
 
-<span {...props} class={classes}>
+<span {...$$restProps} class={classes}>
   <slot />
 </span>

--- a/src/Jumbotron.svelte
+++ b/src/Jumbotron.svelte
@@ -1,23 +1,21 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let fluid = false;
   export let tag = 'div';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'jumbotron', fluid ? 'jumbotron-fluid' : false);
 </script>
 
 {#if tag === 'section'}
-  <section {...props} class={classes}>
+  <section {...$$restProps} class={classes}>
     <slot />
   </section>
 {:else}
-  <div {...props} class={classes}>
+  <div {...$$restProps} class={classes}>
     <slot />
   </div>
 {/if}

--- a/src/Label.svelte
+++ b/src/Label.svelte
@@ -1,12 +1,10 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   import { getColumnSizeClass, isObject } from './utils';
 
   let className = '';
 
-  const props = clean($$props);
 
   export { className as class };
   export let hidden = false;
@@ -71,6 +69,6 @@
   );
 </script>
 
-<label {...props} {id} class={classes} for={fore}>
+<label {...$$restProps} {id} class={classes} for={fore}>
   <slot />
 </label>

--- a/src/ListGroup.svelte
+++ b/src/ListGroup.svelte
@@ -1,12 +1,10 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let flush = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -15,6 +13,6 @@
   );
 </script>
 
-<ul {...props} class={classes}>
+<ul {...$$restProps} class={classes}>
   <slot />
 </ul>

--- a/src/ListGroupItem.svelte
+++ b/src/ListGroupItem.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -11,7 +10,6 @@
   export let href = null;
   export let tag = null;
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -24,15 +22,15 @@
 </script>
 
 {#if href}
-  <a {...props} class={classes} {href} {disabled} {active}>
+  <a {...$$restProps} class={classes} {href} {disabled} {active}>
     <slot />
   </a>
 {:else if tag === 'button'}
-  <button {...props} class={classes} type="button" on:click {disabled} {active}>
+  <button {...$$restProps} class={classes} type="button" on:click {disabled} {active}>
     <slot />
   </button>
 {:else}
-  <li {...props} class={classes} {disabled} {active}>
+  <li {...$$restProps} class={classes} {disabled} {active}>
     <slot />
   </li>
 {/if}

--- a/src/Media.svelte
+++ b/src/Media.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -17,7 +16,6 @@
   export let src = '';
   export let alt = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, {
     'media-body': body,
@@ -43,21 +41,21 @@
 </script>
 
 {#if heading}
-  <h4 {...props} class={classes}>
+  <h4 {...$$restProps} class={classes}>
     <slot />
   </h4>
 {:else if href}
-  <a {...props} class={classes} {href}>
+  <a {...$$restProps} class={classes} {href}>
     <slot />
   </a>
 {:else if src || object}
-  <img {...props} class={classes} {src} {alt} />
+  <img {...$$restProps} class={classes} {src} {alt} />
 {:else if list}
-  <ul {...props} class={classes}>
+  <ul {...$$restProps} class={classes}>
     <slot />
   </ul>
 {:else}
-  <div {...props} class={classes}>
+  <div {...$$restProps} class={classes}>
     <slot />
   </div>
 {/if}

--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -5,7 +5,7 @@
 
 <script>
   import clsx from 'clsx';
-  import { clean, browserEvent } from './utils';
+  import { browserEvent } from './utils';
   import { onDestroy, onMount, afterUpdate } from 'svelte';
   import { fade as fadeTransition } from 'svelte/transition';
 
@@ -43,7 +43,6 @@
   export let transitionType = fadeTransition;
   export let transitionOptions = {};
 
-  const props = clean($$props);
 
   let hasOpened = false;
   let _isMounted = false;
@@ -213,7 +212,7 @@
 
 {#if _isMounted}
   <div
-    {...props}
+    {...$$restProps}
     class={wrapClassName}
     tabindex="-1"
     style="position: relative; z-index: {zIndex}">

--- a/src/ModalBody.svelte
+++ b/src/ModalBody.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'modal-body');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/ModalFooter.svelte
+++ b/src/ModalFooter.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'modal-footer');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/ModalHeader.svelte
+++ b/src/ModalHeader.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -9,7 +8,6 @@
   export let charCode = 215;
   export let children = undefined;
 
-  const props = clean($$props);
 
   $: closeIcon =
     typeof charCode === 'number' ? String.fromCharCode(charCode) : charCode;
@@ -17,7 +15,7 @@
   $: classes = clsx(className, 'modal-header');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <h5 class="modal-title">
     {#if children}
       {children}

--- a/src/Nav.svelte
+++ b/src/Nav.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -13,7 +12,6 @@
   export let navbar = false;
   export let card = false;
 
-  const props = clean($$props);
 
   function getVerticalClass(vertical) {
     if (vertical === false) {
@@ -40,6 +38,6 @@
   );
 </script>
 
-<ul {...props} class={classes}>
+<ul {...$$restProps} class={classes}>
   <slot />
 </ul>

--- a/src/NavItem.svelte
+++ b/src/NavItem.svelte
@@ -1,16 +1,14 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let active = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'nav-item', active ? 'active' : false);
 </script>
 
-<li {...props} class={classes}>
+<li {...$$restProps} class={classes}>
   <slot />
 </li>

--- a/src/NavLink.svelte
+++ b/src/NavLink.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -8,7 +7,6 @@
   export let active = false;
   export let href = '#';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'nav-link', {
     disabled,
@@ -28,6 +26,6 @@
   }
 </script>
 
-<a {...props} {href} on:click on:click={handleClick} class={classes}>
+<a {...$$restProps} {href} on:click on:click={handleClick} class={classes}>
   <slot />
 </a>

--- a/src/Navbar.svelte
+++ b/src/Navbar.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -11,7 +10,6 @@
   export let color = '';
   export let expand = false;
 
-  const props = clean($$props);
 
   function getExpandClass(expand) {
     if (expand === false) {
@@ -32,6 +30,6 @@
   });
 </script>
 
-<nav {...props} class={classes}>
+<nav {...$$restProps} class={classes}>
   <slot />
 </nav>

--- a/src/NavbarBrand.svelte
+++ b/src/NavbarBrand.svelte
@@ -1,16 +1,14 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let href = '/';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'navbar-brand');
 </script>
 
-<a {...props} class={classes} {href}>
+<a {...$$restProps} class={classes} {href}>
   <slot />
 </a>

--- a/src/NavbarToggler.svelte
+++ b/src/NavbarToggler.svelte
@@ -1,18 +1,16 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   import Button from './Button.svelte';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'navbar-toggler');
 </script>
 
-<Button {...props} on:click class={classes}>
+<Button {...$$restProps} on:click class={classes}>
   <slot>
     <span class="navbar-toggler-icon" />
   </slot>

--- a/src/Pagination.svelte
+++ b/src/Pagination.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -8,7 +7,6 @@
   export let size = '';
   export let ariaLabel = 'pagination';
 
-  const props = clean($$props);
 
   $: classes = clsx(className);
 
@@ -17,7 +15,7 @@
   });
 </script>
 
-<nav {...props} class={classes} aria-label={ariaLabel}>
+<nav {...$$restProps} class={classes} aria-label={ariaLabel}>
   <ul class={listClasses}>
     <slot />
   </ul>

--- a/src/PaginationItem.svelte
+++ b/src/PaginationItem.svelte
@@ -1,13 +1,11 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
   export let active = false;
   export let disabled = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'page-item', {
     active,
@@ -15,6 +13,6 @@
   });
 </script>
 
-<li {...props} class={classes}>
+<li {...$$restProps} class={classes}>
   <slot />
 </li>

--- a/src/PaginationLink.svelte
+++ b/src/PaginationLink.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -11,7 +10,6 @@
   export let ariaLabel = '';
   export let href = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'page-link');
 
@@ -41,7 +39,7 @@
   }
 </script>
 
-<a {...props} class={classes} on:click {href}>
+<a {...$$restProps} class={classes} on:click {href}>
   {#if previous || next || first || last}
     <span aria-hidden="true">
       <slot> {defaultCaret} </slot>

--- a/src/Progress.svelte
+++ b/src/Progress.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
   import toNumber from 'lodash.tonumber';
 
   let className = '';
@@ -14,7 +13,6 @@
   export let color = '';
   export let barClassName = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'progress');
 
@@ -34,7 +32,7 @@
     <slot />
   {:else}
     <div
-      {...props}
+      {...$$restProps}
       class={progressBarClasses}
       style="width: {percent}%"
       role="progressbar"
@@ -45,7 +43,7 @@
     </div>
   {/if}
 {:else}
-  <div {...props} class={classes}>
+  <div {...$$restProps} class={classes}>
     {#if multi}
       <slot />
     {:else}

--- a/src/Readme.md
+++ b/src/Readme.md
@@ -1,18 +1,5 @@
 # Code Notes
 
-This pattern is used for omitting props from spread props:
-
-```javascript
-const props = clean($$props);
-```
-The remaining props are then spread to component:
-
-```html
-<div {...props} class="{classes}">
-```
-
-----
-
 This pattern is used to allow testing of Svelte slots:
 
 ```

--- a/src/Row.svelte
+++ b/src/Row.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -8,7 +7,6 @@
   export let form = false;
   export let id = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -17,6 +15,6 @@
   );
 </script>
 
-<div {...props} {id} class={classes}>
+<div {...$$restProps} {id} class={classes}>
   <slot />
 </div>

--- a/src/Spinner.svelte
+++ b/src/Spinner.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -8,7 +7,6 @@
   export let size = '';
   export let color = '';
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -18,7 +16,7 @@
   );
 </script>
 
-<div {...props} role="status" class={classes}>
+<div {...$$restProps} role="status" class={classes}>
   <span class="sr-only">
     <slot>Loading...</slot>
   </span>

--- a/src/TabContent.svelte
+++ b/src/TabContent.svelte
@@ -1,13 +1,11 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
   import { context } from './TabContext';
 
   let className = '';
   export { className as class };
   export let activeTab;
 
-  const props = clean($$props);
 
   $: classes = clsx('tab-content', className);
 
@@ -18,6 +16,6 @@
   });
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/TabPane.svelte
+++ b/src/TabPane.svelte
@@ -1,19 +1,17 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
   import { context } from './TabContext';
 
   let className = '';
   export { className as class };
   export let tabId;
 
-  const props = clean($$props);
 
   $: classes = clsx('tab-pane', className, {
     active: tabId === $context.activeTabId
   });
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/Table.svelte
+++ b/src/Table.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -12,7 +11,6 @@
   export let hover = false;
   export let responsive = false;
 
-  const props = clean($$props);
 
   $: classes = clsx(
     className,
@@ -31,12 +29,12 @@
 
 {#if responsive}
   <div class={responsiveClassName}>
-    <table {...props} class={classes}>
+    <table {...$$restProps} class={classes}>
       <slot />
     </table>
   </div>
 {:else}
-  <table {...props} class={classes}>
+  <table {...$$restProps} class={classes}>
     <slot />
   </table>
 {/if}

--- a/src/Toast.svelte
+++ b/src/Toast.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
   import { fade as fadeTrans } from 'svelte/transition';
 
   let className = '';
@@ -9,7 +8,6 @@
   export let fade = true;
   export let isOpen = true;
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'toast', {
     show: isOpen
@@ -18,7 +16,7 @@
 
 {#if isOpen}
   <div
-    {...props}
+    {...$$restProps}
     class={classes}
     transition:fadeTrans={{ duration: fade && duration }}
     role="alert">

--- a/src/ToastBody.svelte
+++ b/src/ToastBody.svelte
@@ -1,15 +1,13 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'toast-body');
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   <slot />
 </div>

--- a/src/ToastHeader.svelte
+++ b/src/ToastHeader.svelte
@@ -1,6 +1,5 @@
 <script>
   import clsx from 'clsx';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -10,7 +9,6 @@
   export let charCode = 215;
   export let close = null;
 
-  const props = clean($$props);
 
   $: classes = clsx(className, 'toast-header');
 
@@ -20,7 +18,7 @@
     typeof charCode === 'number' ? String.fromCharCode(charCode) : charCode;
 </script>
 
-<div {...props} class={classes}>
+<div {...$$restProps} class={classes}>
   {#if icon}
     <svg
       class={`rounded text-${icon}`}

--- a/src/UncontrolledAlert.svelte
+++ b/src/UncontrolledAlert.svelte
@@ -1,11 +1,9 @@
 <script>
   import Alert from './Alert.svelte';
-  import { clean } from './utils';
 
   let isOpen = true;
-  const props = clean($$props);
 </script>
 
-<Alert {...props} {isOpen} toggle={() => (isOpen = false)}>
+<Alert {...$$restProps} {isOpen} toggle={() => (isOpen = false)}>
   <slot />
 </Alert>

--- a/src/UncontrolledButtonDropdown.svelte
+++ b/src/UncontrolledButtonDropdown.svelte
@@ -1,6 +1,5 @@
 <script>
   import ButtonDropdown from './ButtonDropdown.svelte';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -17,11 +16,10 @@
   export let defaultOpen = false;
 
   let isOpen = defaultOpen;
-  const props = clean($$props);
 </script>
 
 <ButtonDropdown
-  {...props}
+  {...$$restProps}
   {isOpen}
   toggle={() => (isOpen = !isOpen)}
   class={className}

--- a/src/UncontrolledCollapse.svelte
+++ b/src/UncontrolledCollapse.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { clean } from './utils';
   import { onMount, onDestroy } from 'svelte';
 
   import Collapse from './Collapse.svelte';
@@ -15,7 +14,6 @@
   export let onExiting = noop;
   export let onExited = noop;
 
-  const props = clean($$props);
 
   let unbindEvents;
   let isOpen = defaultOpen;
@@ -67,7 +65,7 @@
 </script>
 
 <Collapse
-  {...props}
+  {...$$restProps}
   {isOpen}
   on:introstart
   on:introend

--- a/src/UncontrolledDropdown.svelte
+++ b/src/UncontrolledDropdown.svelte
@@ -1,6 +1,5 @@
 <script>
   import Dropdown from './Dropdown.svelte';
-  import { clean } from './utils';
 
   let className = '';
   export { className as class };
@@ -17,11 +16,10 @@
   export let defaultOpen = false;
 
   let isOpen = defaultOpen;
-  const props = clean($$props);
 </script>
 
 <Dropdown
-  {...props}
+  {...$$restProps}
   {isOpen}
   toggle={() => (isOpen = !isOpen)}
   class={className}

--- a/src/UncontrolledFade.svelte
+++ b/src/UncontrolledFade.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { clean } from './utils';
   import { onMount, onDestroy } from 'svelte';
 
   import Fade from './Fade.svelte';
@@ -15,7 +14,6 @@
   export let onExiting = noop;
   export let onExited = noop;
 
-  const props = clean($$props);
 
   let unbindEvents;
   let isOpen = defaultOpen;
@@ -67,7 +65,7 @@
 </script>
 
 <Fade
-  {...props}
+  {...$$restProps}
   {isOpen}
   on:introstart
   on:introend

--- a/stories/custominput/Sample.svelte
+++ b/stories/custominput/Sample.svelte
@@ -113,7 +113,7 @@
       <option>Value 5</option>
     </CustomInput>
   </FormGroup>
-  <FormGroup>
+  <!-- <FormGroup>
     <Label for="exampleCustomMutlipleSelect">Custom Multiple Select</Label>
     <CustomInput
       type="select"
@@ -127,7 +127,7 @@
       <option>Value 4</option>
       <option>Value 5</option>
     </CustomInput>
-  </FormGroup>
+  </FormGroup> -->
   <FormGroup>
     <Label for="exampleCustomSelectDisabled">Custom Select Disabled</Label>
     <CustomInput
@@ -143,7 +143,7 @@
       <option>Value 5</option>
     </CustomInput>
   </FormGroup>
-  <FormGroup>
+  <!-- <FormGroup>
     <Label for="exampleCustomMutlipleSelectDisabled">
       Custom Multiple Select Disabled
     </Label>
@@ -160,7 +160,7 @@
       <option>Value 4</option>
       <option>Value 5</option>
     </CustomInput>
-  </FormGroup>
+  </FormGroup> -->
   <FormGroup>
     <Label for="exampleCustomFileBrowser">File Browser</Label>
     <CustomInput type="file" id="exampleCustomFileBrowser" name="customFile" />

--- a/stories/input/Sample.svelte
+++ b/stories/input/Sample.svelte
@@ -89,7 +89,7 @@
       <option>5</option>
     </Input>
   </FormGroup>
-  <FormGroup>
+  <!-- <FormGroup>
     <Label for="exampleSelectMulti">Select Multiple</Label>
     <Input type="select" name="selectMulti" id="exampleSelectMulti" multiple>
       <option>1</option>
@@ -98,7 +98,7 @@
       <option>4</option>
       <option>5</option>
     </Input>
-  </FormGroup>
+  </FormGroup> -->
   <FormGroup>
     <Label for="exampleText">Text Area</Label>
     <Input type="textarea" name="text" id="exampleText" />


### PR DESCRIPTION
Move to `$$restProps`, removes unneeded clean props code
Disable select multiple, broken with 3.24, pending fix