### PR TITLE
hotfix: refactored svelte type def to exclude svelte library.

### DIFF
--- a/@types/shared.d.ts
+++ b/@types/shared.d.ts
@@ -1,5 +1,3 @@
-import { SvelteComponentDev } from 'svelte/internal';
-
 /**
  * Valid Bootstrap colors
  */
@@ -25,11 +23,9 @@ type LocalSvelteProps = {
  * Local svelte class for adding typescript definitions for svelte components
  *
  */
-export declare class LocalSvelteComponent<
-  Props = {}
-> extends SvelteComponentDev {
+export declare class LocalSvelteComponent<Props = {}> {
   constructor(props: Props & LocalSvelteProps);
-
+  $$prop_def: Props & LocalSvelteProps;
   render: undefined;
   context: undefined;
   setState: undefined;


### PR DESCRIPTION
I realized when the svelte package was installed as a devDependency the type definition i wrote extending svelte was not loaded despite having a peerDependency.