### PR TITLE
fix #140 - Add events to checkbox, switch, and radio inputs

### DIFF
--- a/src/CustomInput.svelte
+++ b/src/CustomInput.svelte
@@ -86,6 +86,10 @@
       type="checkbox"
       class={customControlClasses}
       bind:checked
+      on:blur
+      on:focus
+      on:change
+      on:input
       {name}
       {disabled}
       {placeholder} />
@@ -99,6 +103,10 @@
       {id}
       type="radio"
       class={customControlClasses}
+      on:blur
+      on:focus
+      on:change
+      on:input
       {name}
       {disabled}
       {placeholder} />


### PR DESCRIPTION
Fix for https://github.com/bestguy/sveltestrap/issues/140.

I saw that radio inputs don't support events either, so patched that too.