### PR TITLE
Col: Remove width attributes from output div to make HTML valid

### DIFF
--- a/src/Col.svelte
+++ b/src/Col.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { getColumnSizeClass, isObject } from './utils';
+  import { getColumnSizeClass, isObject, cleanRestProps } from './utils';
 
   let className = '';
   export { className as class };
@@ -45,6 +45,6 @@
   }
 </script>
 
-<div {...$$restProps} class={colClasses.join(' ')}>
+<div {...cleanRestProps($$restProps, widths)} class={colClasses.join(' ')}>
   <slot />
 </div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,6 +104,18 @@ function toClassName(value) {
   return result;
 }
 
+export function cleanRestProps(restProps, excludeProperties) {
+    if (!excludeProperties) {
+      return restProps;
+    }
+    const keys = Object.keys(restProps).filter(key => excludeProperties.indexOf(key) === -1);
+    const rest = {};
+    for (const key of keys) {
+      rest[key] = restProps[key];
+    }
+    return rest;
+}
+
 export default function classnames(...args) {
   return args.map(toClassName).filter(Boolean).join(' ');
 }


### PR DESCRIPTION
Using `{...$$restProps}` on the output `<div>` appends Svelte attributes like `xs` or `md` to the rendered `<div>` element which is invalid in terms of the W3 specs. I added a new helper function (I did see your `clean` func but wasn't sure if this was intended for that purpose) that retrieves an array of attribute names and omits these in the given object. That way, you can still pass anything to your `<Col>` component and render it on the resulting div but at least the attributes that you know belong to your implementation are getting cut.

Before: 

`<Col md="5" data-whatever="hi" />` => `<div class="col-md-5" md="5" data-whatever="hi">`

After: 

`<Col md="5" data-whatever="hi" />` => `<div class="col-md-5" data-whatever="hi">`