### PR TITLE
Correct Collapse when in navbar

### DIFF
--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -56,7 +56,7 @@
 
 {#if isOpen}
   <div
-    style="overflow: hidden;"
+    style={navbar ? undefined : 'overflow: hidden;'}
     {...$$restProps}
     class={classes}
     transition:slide|local


### PR DESCRIPTION
Conditionally hide overflow only when not in navbar