### PR TITLE
Fixed #200

### DIFF
--- a/src/Carousel.svelte
+++ b/src/Carousel.svelte
@@ -20,19 +20,19 @@
 
   onMount(() => {
     setRideTimeout();
-  });
 
-  _removeVisibilityChangeListener = browserEvent(
-    document,
-    'visibilitychange',
-    () => {
-      if (document.visibilityState === 'hidden') {
-        clearRideTimeout();
-      } else {
-        setRideTimeout();
+    _removeVisibilityChangeListener = browserEvent(
+      document,
+      'visibilitychange',
+      () => {
+        if (document.visibilityState === 'hidden') {
+          clearRideTimeout();
+        } else {
+          setRideTimeout();
+        }
       }
-    }
-  );
+    );
+  });
 
   onDestroy(() => {
     if (_rideTimeoutId) {


### PR DESCRIPTION
```
document is not defined

ReferenceError: document is not defined
    at [...]/node_modules/sveltestrap/src/Carousel.svelte:26:12
```

Which points to this:

```
  [...]
  onMount(() => {
    setRideTimeout();
  });

  _removeVisibilityChangeListener = browserEvent(
    document,     <------  this line!
    'visibilitychange',
    () => {
      if (document.visibilityState === 'hidden') {
        clearRideTimeout();
      } else {
        setRideTimeout();
      }
    }
  );
  [...]
```

According to [this StackOverflow answer](https://stackoverflow.com/a/56184892), the problem appears to be connected to the fact that `document` is only available after the component has been mounted.

I though, as a very noob on Svelte, to just chuck the assignment to `_removeVisibilityChangeListener` inside the `onMount` callback, and appears to be working just fine.
```
  onMount(() => {
    setRideTimeout();

    _removeVisibilityChangeListener = browserEvent(
      document,
      "visibilitychange",
      () => {
        if (document.visibilityState === "hidden") {
          clearRideTimeout();
        } else {
          setRideTimeout();
        }
      }
    );
  });
```

Node version: v12.19.0
Svelte: v3.17.3
Sveltestrap: v3.9.4
Sapper: v0.28.0