### PR TITLE
fix typescript errors

### DIFF
--- a/src/ButtonDropdown.d.ts
+++ b/src/ButtonDropdown.d.ts
@@ -1,9 +1,6 @@
-import { UncontrolledDropdownProps, IDropdownProps } from './Dropdown';
+import { IDropdownProps } from './Dropdown';
 import { LocalSvelteComponent } from './shared';
-export {
-  UncontrolledDropdownProps as UncontrolledButtonDropdownProps,
-  IDropdownProps as ButtonDropdownProps
-};
+export { IDropdownProps as ButtonDropdownProps };
 
 declare class ButtonDropdown extends LocalSvelteComponent<IDropdownProps> {}
 export default ButtonDropdown;

--- a/src/FormGroup.d.ts
+++ b/src/FormGroup.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { LocalSvelteComponent } from './shared';
 
 export interface FormGroupProps {

--- a/src/ListGroupItem.d.ts
+++ b/src/ListGroupItem.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { LocalSvelteComponent, Color } from './shared';
 
 export interface IListGroupItemProps {

--- a/src/Modal.d.ts
+++ b/src/Modal.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { IFadeProps } from './Fade';
 import { LocalSvelteComponent } from './shared';
 

--- a/src/PaginationLink.d.ts
+++ b/src/PaginationLink.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { LocalSvelteComponent } from './shared';
 
 export interface IPaginationLinkProps {

--- a/src/ToastHeader.d.ts
+++ b/src/ToastHeader.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { LocalSvelteComponent } from './shared';
 
 export interface IToastHeaderProps {


### PR DESCRIPTION
While running on the latest version of `sveltestrap` (`3.9.5`), I encountered a number of typescript errors:

```
node_modules/sveltestrap/src/ButtonDropdown.d.ts:1:10 - error TS2614: Module '"./Dropdown"' has no exported member 'UncontrolledDropdownProps'. Did you mean to use 'import UncontrolledDropdownProps from "./Dropdown"' instead?

1 import { UncontrolledDropdownProps, IDropdownProps } from './Dropdown';
           ~~~~~~~~~~~~~~~~~~~~~~~~~
node_modules/sveltestrap/src/FormGroup.d.ts:9:18 - error TS2503: Cannot find namespace 'React'.

9   tag?: string | React.ReactType;
                   ~~~~~
node_modules/sveltestrap/src/ListGroupItem.d.ts:10:13 - error TS2503: Cannot find namespace 'React'.

10   onClick?: React.MouseEventHandler<any>;
               ~~~~~
node_modules/sveltestrap/src/Modal.d.ts:24:14 - error TS2503: Cannot find namespace 'React'.

24   external?: React.ReactNode;
                ~~~~~
node_modules/sveltestrap/src/PaginationLink.d.ts:10:19 - error TS2503: Cannot find namespace 'React'.

10   href?: string | React.ReactType;
                     ~~~~~
node_modules/sveltestrap/src/ToastHeader.d.ts:6:11 - error TS2503: Cannot find namespace 'React'.

6   close?: React.ReactNode;
            ~~~~~
```

This PR just aims at solving those.