### PR TITLE
Clean Dropdown listeners if component is destroyed

### DIFF
--- a/src/Dropdown.svelte
+++ b/src/Dropdown.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { setContext } from 'svelte';
+  import { setContext, onDestroy } from 'svelte';
   import classnames from './utils';
 
   import { createContext } from './DropdownContext';
@@ -91,6 +91,11 @@
 
     toggle(e);
   }
+  onDestroy(() => {
+    ['click', 'touchstart', 'keyup'].forEach((event) =>
+      document.removeEventListener(event, handleDocumentClick, true)
+    );
+  });
 </script>
 
 {#if nav}


### PR DESCRIPTION
This change prevents leaving dangling listeners that will keep causing errors if the component is destroyed while the dropdown is open.