### PR TITLE
Re-add Jumbotron

### DIFF
--- a/src/Jumbotron.d.ts
+++ b/src/Jumbotron.d.ts
@@ -1,0 +1,10 @@
+import { SvelteComponentTyped } from 'svelte';
+
+export interface JumbotronProps
+  extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> { }
+
+export default class Jumbotron extends SvelteComponentTyped<
+  JumbotronProps,
+  {},
+  { default: {} }
+> {}

--- a/src/Jumbotron.svelte
+++ b/src/Jumbotron.svelte
@@ -1,0 +1,12 @@
+<script>
+  import classnames from './utils';
+
+  let className = '';
+  export { className as class };
+
+  $: classes = classnames(className, 'p-5 mb-4 bg-light rounded-3');
+</script>
+
+<div class={classes}>
+  <slot />
+</div>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,6 +42,7 @@ import Icon from './Icon';
 import Input from './Input';
 import InputGroup from './InputGroup';
 import InputGroupText from './InputGroupText';
+import Jumbotron from './Jumbotron';
 import Label from './Label';
 import ListGroup from './ListGroup';
 import ListGroupItem from './ListGroupItem';
@@ -122,6 +123,7 @@ export {
   Input,
   InputGroup,
   InputGroupText,
+  Jumbotron,
   Label,
   ListGroup,
   ListGroupItem,

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ export { default as Icon } from './Icon.svelte';
 export { default as Input } from './Input.svelte';
 export { default as InputGroup } from './InputGroup.svelte';
 export { default as InputGroupText } from './InputGroupText.svelte';
+export { default as Jumbotron } from './Jumbotron.svelte';
 export { default as Label } from './Label.svelte';
 export { default as ListGroup } from './ListGroup.svelte';
 export { default as ListGroupItem } from './ListGroupItem.svelte';


### PR DESCRIPTION
Helps with backwards compatibility, uses equivalent utility classes.
Exported but not added to docs.