### PR TITLE
Check if document is defined in onDestroy in Portal

### DIFF
--- a/src/Portal.svelte
+++ b/src/Portal.svelte
@@ -10,7 +10,9 @@
   });
 
   onDestroy(() => {
-    document.body.removeChild(portal);
+    if (typeof document !== 'undefined') {
+      document.body.removeChild(portal);
+    }
   });
 </script>
 


### PR DESCRIPTION
Trying to use components like Offcanvas, which imports Portal, would
cause SSR to fail. This patch fixes that by checking if `document`
exists before trying to do anything with it.

This PR resolves https://github.com/bestguy/sveltestrap/issues/286.