### PR TITLE
Expose input root

### DIFF
--- a/src/Input.d.ts
+++ b/src/Input.d.ts
@@ -62,5 +62,5 @@ export default class Input extends SvelteComponentTyped<
     input: WindowEventMap['input'];
   },
   { default: {} }
-> { }
+> {}
 

--- a/src/Input.d.ts
+++ b/src/Input.d.ts
@@ -47,7 +47,7 @@ export interface InputProps
   type?: InputType;
   valid?: boolean;
   value?: string;
-  root?: HTMLElement;
+  inner?: HTMLElement;
 }
 
 export default class Input extends SvelteComponentTyped<

--- a/src/Input.d.ts
+++ b/src/Input.d.ts
@@ -47,6 +47,7 @@ export interface InputProps
   type?: InputType;
   valid?: boolean;
   value?: string;
+  root?: HTMLElement;
 }
 
 export default class Input extends SvelteComponentTyped<
@@ -61,5 +62,5 @@ export default class Input extends SvelteComponentTyped<
     input: WindowEventMap['input'];
   },
   { default: {} }
-> {}
+> { }
 

--- a/src/Input.svelte
+++ b/src/Input.svelte
@@ -6,7 +6,7 @@
   let className = '';
   export { className as class };
 
-  export let root;
+  export let inner;
 
   export let bsSize = undefined;
   export let checked = false;
@@ -76,9 +76,7 @@
       size = undefined;
     }
 
-    classes = classnames(
-      className,
-      formControlClass,
+    classes = classnames(className, formControlClass,
       { 
         'is-invalid': invalid,
         'is-valid': valid,
@@ -107,7 +105,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -125,7 +123,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -143,7 +141,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -161,7 +159,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -180,7 +178,7 @@
       on:keyup
       bind:files
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {disabled}
       {invalid}
       {multiple}
@@ -204,7 +202,7 @@
       bind:checked
       bind:group
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {disabled}
       {invalid}
       {label}
@@ -225,7 +223,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -243,7 +241,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {readonly}
       {name}
       {disabled}
@@ -261,7 +259,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -279,7 +277,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -296,7 +294,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {readonly}
       class={classes}
       {name}
@@ -314,7 +312,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {readonly}
       class={classes}
       {name}
@@ -332,7 +330,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {readonly}
       class={classes}
       {name}
@@ -350,7 +348,7 @@
       on:keypress
       on:keyup
       bind:value
-      bind:this={root}
+      bind:this={inner}
       {readonly}
       class={classes}
       {name}
@@ -386,7 +384,7 @@
     on:keypress
     on:keyup
     bind:value
-    bind:this={root}
+    bind:this={inner}
     {disabled}
     {name}
     {placeholder}
@@ -400,7 +398,7 @@
     on:focus
     on:input
     bind:value
-    bind:this={root}
+    bind:this={inner}
     {name}
     {disabled}
     {readonly}>
@@ -417,7 +415,7 @@
     on:change
     on:input
     bind:value
-    bind:this={root}
+    bind:this={inner}
     {name}
     {disabled}>
     <slot />

--- a/src/Input.svelte
+++ b/src/Input.svelte
@@ -76,12 +76,16 @@
       size = undefined;
     }
 
-    classes = classnames(className, formControlClass, {
-      'is-invalid': invalid,
-      'is-valid': valid,
-      [`form-control-${bsSize}`]: bsSize && !isBtn,
-      [`btn-${bsSize}`]: bsSize && isBtn
-    });
+    classes = classnames(
+      className,
+      formControlClass,
+      { 
+        'is-invalid': invalid,
+        'is-valid': valid,
+        [`form-control-${bsSize}`]: bsSize && !isBtn,
+        [`btn-${bsSize}`]: bsSize && isBtn
+      }
+    );
   }
 
   const handleInput = (event) => {
@@ -184,7 +188,7 @@
       {placeholder}
       {readonly}
       {valid} />
-  {:else if type === 'checkbox' || type === 'radio' || type === 'switch'}
+  {:else if (type === 'checkbox' || type === 'radio' || type === 'switch')}
     <FormCheck
       {...$$restProps}
       class={className}

--- a/src/Input.svelte
+++ b/src/Input.svelte
@@ -6,6 +6,8 @@
   let className = '';
   export { className as class };
 
+  export let root;
+
   export let bsSize = undefined;
   export let checked = false;
   export let color = undefined;
@@ -42,10 +44,10 @@
         break;
       case 'select':
         formControlClass = `form-select`;
-        tag = 'select'
+        tag = 'select';
         break;
       case 'textarea':
-        tag = 'textarea'
+        tag = 'textarea';
         break;
       case 'button':
       case 'reset':
@@ -74,16 +76,12 @@
       size = undefined;
     }
 
-    classes = classnames(
-      className,
-      formControlClass,
-      { 
-        'is-invalid': invalid,
-        'is-valid': valid,
-        [`form-control-${bsSize}`]: bsSize && !isBtn,
-        [`btn-${bsSize}`]: bsSize && isBtn
-      }
-    );
+    classes = classnames(className, formControlClass, {
+      'is-invalid': invalid,
+      'is-valid': valid,
+      [`form-control-${bsSize}`]: bsSize && !isBtn,
+      [`btn-${bsSize}`]: bsSize && isBtn
+    });
   }
 
   const handleInput = (event) => {
@@ -105,12 +103,13 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {disabled}
       {name}
       {placeholder}
       {readonly} />
-    {:else if type === 'password'}
-      <input
+  {:else if type === 'password'}
+    <input
       {...$$restProps}
       class={classes}
       type="password"
@@ -122,6 +121,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {disabled}
       {name}
       {placeholder}
@@ -139,6 +139,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {disabled}
       {name}
       {placeholder}
@@ -156,6 +157,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {disabled}
       {name}
       {placeholder}
@@ -174,6 +176,7 @@
       on:keyup
       bind:files
       bind:value
+      bind:this={root}
       {disabled}
       {invalid}
       {multiple}
@@ -181,12 +184,12 @@
       {placeholder}
       {readonly}
       {valid} />
-  {:else if (type === 'checkbox' || type === 'radio' || type === 'switch')}
+  {:else if type === 'checkbox' || type === 'radio' || type === 'switch'}
     <FormCheck
       {...$$restProps}
       class={className}
       size={bsSize}
-      type={type}
+      {type}
       on:blur
       on:change
       on:focus
@@ -197,6 +200,7 @@
       bind:checked
       bind:group
       bind:value
+      bind:this={root}
       {disabled}
       {invalid}
       {label}
@@ -217,6 +221,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {disabled}
       {name}
       {placeholder}
@@ -234,6 +239,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {readonly}
       {name}
       {disabled}
@@ -251,6 +257,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {disabled}
       {name}
       {placeholder}
@@ -268,6 +275,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {disabled}
       {name}
       {placeholder}
@@ -284,6 +292,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {readonly}
       class={classes}
       {name}
@@ -301,6 +310,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {readonly}
       class={classes}
       {name}
@@ -318,6 +328,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {readonly}
       class={classes}
       {name}
@@ -335,6 +346,7 @@
       on:keypress
       on:keyup
       bind:value
+      bind:this={root}
       {readonly}
       class={classes}
       {name}
@@ -370,6 +382,7 @@
     on:keypress
     on:keyup
     bind:value
+    bind:this={root}
     {disabled}
     {name}
     {placeholder}
@@ -383,6 +396,7 @@
     on:focus
     on:input
     bind:value
+    bind:this={root}
     {name}
     {disabled}
     {readonly}>
@@ -399,6 +413,7 @@
     on:change
     on:input
     bind:value
+    bind:this={root}
     {name}
     {disabled}>
     <slot />

--- a/stories/input/Binding.svelte
+++ b/stories/input/Binding.svelte
@@ -2,6 +2,12 @@
   import { FormGroup, Input, Label } from 'sveltestrap';
 
   let inputValue = '';
+
+  let root: HTMLTextAreaElement;
+  const resize = () => {
+    root.style.height = 'auto';
+    root.style.height = 4 + root.scrollHeight + 'px';
+  };
 </script>
 
 <FormGroup>
@@ -11,3 +17,8 @@
 {#if inputValue}
   <p>You typed: {inputValue}</p>
 {/if}
+
+<FormGroup>
+  <Label>This textarea resizes as you type</Label>
+  <Input rows={1} type="textarea" bind:root on:input={resize} />
+</FormGroup>

--- a/stories/input/Binding.svelte
+++ b/stories/input/Binding.svelte
@@ -3,10 +3,10 @@
 
   let inputValue = '';
 
-  let root: HTMLTextAreaElement;
+  let inner: HTMLTextAreaElement;
   const resize = () => {
-    root.style.height = 'auto';
-    root.style.height = 4 + root.scrollHeight + 'px';
+    inner.style.height = 'auto';
+    inner.style.height = 4 + inner.scrollHeight + 'px';
   };
 </script>
 
@@ -20,5 +20,5 @@
 
 <FormGroup>
   <Label>This textarea resizes as you type</Label>
-  <Input rows={1} type="textarea" bind:root on:input={resize} />
+  <Input rows={1} type="textarea" bind:inner on:input={resize} />
 </FormGroup>

--- a/stories/input/Index.svelte
+++ b/stories/input/Index.svelte
@@ -25,6 +25,9 @@
   <p slot="info">
     The recommended way to bind values to Inputs is via
     <code>{snippet}</code>
+    <br />
+    The Input component also exposes its root HTMLElement with
+    <code>bind:root</code>
   </p>
   <Binding />
 </Example>

--- a/stories/input/Index.svelte
+++ b/stories/input/Index.svelte
@@ -26,8 +26,8 @@
     The recommended way to bind values to Inputs is via
     <code>{snippet}</code>
     <br />
-    The Input component also exposes its root HTMLElement with
-    <code>bind:root</code>
+    The Input component also exposes its inner HTMLElement with
+    <code>bind:nner</code>
   </p>
   <Binding />
 </Example>

--- a/stories/input/Index.svelte
+++ b/stories/input/Index.svelte
@@ -27,7 +27,7 @@
     <code>{snippet}</code>
     <br />
     The Input component also exposes its inner HTMLElement with
-    <code>bind:nner</code>
+    <code>bind:inner</code>
   </p>
   <Binding />
 </Example>


### PR DESCRIPTION
Following up on #295, I've made some changes to the Input component that allow its root input element to be exposed outside the component.

I've included an example in the input story to show how this can be used to make an auto-resizing textarea.