### PR TITLE
Add static modal backdrop support

### DIFF
--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -163,7 +163,7 @@
       }
 
       const backdropElem = _dialog ? _dialog.parentNode : null;
-      if (backdropElem && e.target === backdropElem && toggle) {
+      if (backdrop === true && backdropElem && e.target === backdropElem && toggle) {
         toggle(e);
       }
     }
@@ -173,7 +173,7 @@
     dispatch('open');
     _removeEscListener = browserEvent(document, 'keydown', (event) => {
       if (event.key && event.key === 'Escape') {
-        toggle(event);
+        if (toggle && backdrop === true) toggle(event);
       }
     });
   }

--- a/stories/modal/Index.svelte
+++ b/stories/modal/Index.svelte
@@ -18,6 +18,8 @@
   import shorthandSource from '!!raw-loader!./Shorthand.svelte';
   import Static from './Static.svelte';
   import staticSource from '!!raw-loader!./Static.svelte';
+  import StaticBackdrop from './StaticBackdrop.svelte';
+  import staticBackdropSource from '!!raw-loader!./StaticBackdrop.svelte';
 </script>
 
 <h1>Modals</h1>
@@ -46,6 +48,10 @@
 
 <Example title="Backdrop" source={backdropSource}>
   <Backdrop />
+</Example>
+
+<Example title="Static Backdrop" source={staticBackdropSource}>
+  <StaticBackdrop />
 </Example>
 
 <Example title="Fade" source={fadeSource}>

--- a/stories/modal/StaticBackdrop.svelte
+++ b/stories/modal/StaticBackdrop.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import {
+    Button,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader
+  } from 'sveltestrap';
+  let open = false;
+  const toggle = () => (open = !open);
+</script>
+
+<div>
+  <Button color="danger" on:click={toggle}>Modal with Static Backdrop</Button>
+  <Modal isOpen={open} backdrop="static" {toggle}>
+    <ModalHeader {toggle}>Modal title</ModalHeader>
+    <ModalBody>
+      Clicking outside modal or hitting Escape does not dismiss.
+    </ModalBody>
+    <ModalFooter>
+      <Button color="primary" on:click={toggle}>Do Something</Button>
+      <Button color="secondary" on:click={toggle}>Cancel</Button>
+    </ModalFooter>
+  </Modal>
+</div>


### PR DESCRIPTION
Disable esc & click on `backdrop="static"`
Fixes #324 

TODO Does not add the "bump" animation but will cover in #296 

