### PR TITLE
Added Fluid Attribute to Carousel

### DIFF
--- a/src/Carousel.d.ts
+++ b/src/Carousel.d.ts
@@ -10,6 +10,7 @@ export interface CarouselProps
   pause?: 'hover' | false;
   ride?: boolean;
   style?: string;
+  fluid?: boolean;
 }
 
 export default class Carousel extends SvelteComponentTyped<

--- a/src/Carousel.svelte
+++ b/src/Carousel.svelte
@@ -14,11 +14,13 @@
   export let interval = 5000;
   export let pause = true;
   export let keyboard = true;
+  export let fluid = false;
   let _rideTimeoutId = false;
   let _removeVisibilityChangeListener = false;
 
   $: classes = classnames(className, 'carousel', 'slide', {
-    'carousel-dark': dark
+    'carousel-dark': dark,
+    'container-fluid': fluid
   });
 
   onMount(() => {

--- a/stories/carousel/FullWidth.svelte
+++ b/stories/carousel/FullWidth.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+    import { Carousel, CarouselItem } from 'sveltestrap';
+  
+    const items = [
+      'data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22800%22%20height%3D%22400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20800%20400%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_15ba800aa1d%20text%20%7B%20fill%3A%23555%3Bfont-weight%3Anormal%3Bfont-family%3AHelvetica%2C%20monospace%3Bfont-size%3A40pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_15ba800aa1d%22%3E%3Crect%20width%3D%22800%22%20height%3D%22400%22%20fill%3D%22%23777%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%22285.921875%22%20y%3D%22218.3%22%3EFirst%20slide%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E',
+      'data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22800%22%20height%3D%22400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20800%20400%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_15ba800aa20%20text%20%7B%20fill%3A%23444%3Bfont-weight%3Anormal%3Bfont-family%3AHelvetica%2C%20monospace%3Bfont-size%3A40pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_15ba800aa20%22%3E%3Crect%20width%3D%22800%22%20height%3D%22400%22%20fill%3D%22%23666%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%22247.3203125%22%20y%3D%22218.3%22%3ESecond%20slide%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E',
+      'data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22800%22%20height%3D%22400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20800%20400%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_15ba800aa21%20text%20%7B%20fill%3A%23333%3Bfont-weight%3Anormal%3Bfont-family%3AHelvetica%2C%20monospace%3Bfont-size%3A40pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_15ba800aa21%22%3E%3Crect%20width%3D%22800%22%20height%3D%22400%22%20fill%3D%22%23555%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%22277%22%20y%3D%22218.3%22%3EThird%20slide%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E'
+    ];
+    let activeIndex = 0;
+  </script>
+  
+  <Carousel {items} bind:activeIndex fluid>
+    <div class="carousel-inner">
+      {#each items as item, index}
+        <CarouselItem bind:activeIndex itemIndex={index}>
+          <img src={item} class="d-block w-100" alt={`${item} ${index + 1}`} />
+        </CarouselItem>
+      {/each}
+    </div>
+  </Carousel>
+  

--- a/stories/carousel/Index.svelte
+++ b/stories/carousel/Index.svelte
@@ -15,6 +15,8 @@
   import DarkSource from '!!raw-loader!./Dark.svelte';
 
   import Example from '../Example.svelte';
+  import FullWidth from './FullWidth.svelte';
+  import FullWidthSource from '!!raw-loader!./FullWidth.svelte';
 </script>
 
 <h1>Carousel</h1>
@@ -28,6 +30,10 @@
 
 <Example title="Slides only" source={sampleSource}>
   <Sample />
+</Example>
+
+<Example title="Full Width" source={FullWidthSource}>
+  <FullWidth />
 </Example>
 
 <Example title="With Controls" source={WithControlsSource}>


### PR DESCRIPTION
Allows Carousel to be created in a `container-fluid` wrapper instead of `container` hence providing the ability to make a Full Width Carousel.

Helps with https://github.com/bestguy/sveltestrap/issues/30#issuecomment-893015804