### PR TITLE
Support disabled attr TabPane

### DIFF
--- a/src/TabPane.d.ts
+++ b/src/TabPane.d.ts
@@ -4,6 +4,7 @@ export interface TabPaneProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
   active?: boolean;
   tab?: string;
+  disabled?: boolean;
   tabId?: number | string;
 }
 

--- a/src/TabPane.svelte
+++ b/src/TabPane.svelte
@@ -7,6 +7,7 @@
   let className = '';
   export { className as class };
   export let active = false;
+  export let disabled = false;
   export let tab = undefined;
   export let tabId = undefined;
 
@@ -26,7 +27,7 @@
 
 {#if tabs}
   <NavItem>
-    <NavLink active={tabOpen} on:click={() => setActiveTab(tabId)}>
+    <NavLink active={tabOpen} {disabled} on:click={() => setActiveTab(tabId)}>
       {#if tab}{tab}{/if}
       <slot name="tab" />
     </NavLink>

--- a/stories/tab/Disabled.svelte
+++ b/stories/tab/Disabled.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { TabContent, TabPane } from 'sveltestrap';
+</script>
+
+<TabContent pills>
+  <TabPane tabId="alpha" tab="Alpha" active>
+    <img
+      alt="Alpha Flight"
+      src="https://upload.wikimedia.org/wikipedia/en/4/49/Alpha_Flight_cast_picture_%28John_Byrne_era%29.gif"
+    />
+  </TabPane>
+  <TabPane tabId="bravo" tab="Bravo">
+    <img
+      alt="Johnny Bravo"
+      src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Johnny_Bravo_series_logo.png/320px-Johnny_Bravo_series_logo.png"
+    />
+  </TabPane>
+  <TabPane tabId="charlie" tab="Charlie" disabled>
+    <img
+      alt="Charlie Brown"
+      src="https://upload.wikimedia.org/wikipedia/en/2/22/Charlie_Brown.png"
+    />
+  </TabPane>
+</TabContent>

--- a/stories/tab/Index.svelte
+++ b/stories/tab/Index.svelte
@@ -10,6 +10,8 @@
   import pillsSource from '!!raw-loader!./Pills.svelte';
   import Vertical from './Vertical.svelte';
   import verticalSource from '!!raw-loader!./Vertical.svelte';
+  import Disabled from './Disabled.svelte';
+  import disabledSource from '!!raw-loader!./Disabled.svelte';
 </script>
 
 <h1>TabContent and TabPane</h1>
@@ -26,6 +28,10 @@
 
 <Example title="Pills" source={pillsSource}>
   <Pills />
+</Example>
+
+<Example title="Disabled" source={disabledSource}>
+  <Disabled />
 </Example>
 
 <Example title="Slots" source={slotsSource}>


### PR DESCRIPTION
Just brings support for "disabled" attribute on TabPane. The TS interface hasn't been updated since it is a simple HTML attribute. 

The storybook has been updated with an example :

![image](https://user-images.githubusercontent.com/34311027/131835174-1f5f8c85-b2c1-454b-9ae0-b9266f990a43.png)