### PR TITLE
Don't animate collapse out on Collapse removal

### DIFF
--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -60,7 +60,7 @@
     {...$$restProps}
     class={classes}
     in:collapseIn
-    out:collapseOut
+    out:collapseOut|local
     on:introstart
     on:introend
     on:outrostart


### PR DESCRIPTION
When removing a whole Navbar with the embedded Collapse, there is an animation going on. However, the animation should work only when collapsing/expanding, not when the whole element is being removed.