### PR TITLE
Add option to hide close button

### DIFF
--- a/src/Offcanvas.d.ts
+++ b/src/Offcanvas.d.ts
@@ -13,6 +13,7 @@ export interface OffcanvasProps
   isOpen: boolean;
   placement?: Placement;
   scroll?: boolean;
+  closeButton?: boolean;
   toggle?: () => void;
 }
 

--- a/src/Offcanvas.svelte
+++ b/src/Offcanvas.svelte
@@ -21,6 +21,7 @@
   export let scroll = false;
   export let style = '';
   export let toggle = undefined;
+  export let closeButton = true;
 
   // TODO support these like Modals:
   // export let autoFocus = true;
@@ -83,8 +84,8 @@
     style={`visibility: ${isOpen || isTransitioning ? 'visible' : 'hidden'};${style}`}
     tabindex="-1"
   >
-    {#if toggle || header || $$slots.header}
-      <OffcanvasHeader {toggle}>
+    {#if (toggle && closeButton) || header || $$slots.header}
+      <OffcanvasHeader {toggle} {closeButton}>
         {#if header}{header}{/if}
         <slot name="header" />
       </OffcanvasHeader>

--- a/src/OffcanvasHeader.d.ts
+++ b/src/OffcanvasHeader.d.ts
@@ -3,6 +3,7 @@ import { SvelteComponentTyped } from 'svelte';
 export interface OffcanvasHeaderProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap['div']> {
   closeAriaLabel?: string;
+  closeButton?: boolean;
   toggle?: () => void;
 }
 

--- a/src/OffcanvasHeader.svelte
+++ b/src/OffcanvasHeader.svelte
@@ -6,6 +6,7 @@
   export let children = undefined;
   export let closeAriaLabel = 'Close';
   export let toggle = undefined;
+  export let closeButton = true;
 
   $: classes = classnames(className, 'offcanvas-header');
 </script>
@@ -19,7 +20,7 @@
     {/if}
   </h5>
   <slot name="close">
-    {#if typeof toggle === 'function'}
+    {#if typeof toggle === 'function' && closeButton}
       <button
         aria-label={closeAriaLabel}
         class="btn-close"

--- a/src/__test__/Offcanvas.spec.js
+++ b/src/__test__/Offcanvas.spec.js
@@ -34,4 +34,16 @@ describe('Offcanvas', () => {
     expect(component.getAttribute('aria-modal')).toBe('true');
     expect(component.getAttribute('role')).toBe('dialog');
   });
+
+  test('should render close button', () => {
+    const { container } = render(Offcanvas, { props: { toggle: () => {} } });
+    const closeButton = container.querySelector('.btn-close');
+    expect(closeButton).not.toBeNull();
+  });
+
+  test('should not render close button', () => {
+    const { container } = render(Offcanvas, { props: { toggle: () => {}, closeButton: false } });
+    const closeButton = container.querySelector('.btn-close');
+    expect(closeButton).toBeNull();
+  });
 });


### PR DESCRIPTION
Sometimes you might want to add a completely custom offcanvas header. Currently to do this you would have to not pass the `toggle` property so that the close button doesn't get rendered but then you'd also have to reimplement the backdrop. This PR adds the option to hide the close button and thus the entire header if you don't need it.

I wasn't sure if I need to commit the dist files (other PRs didn't). Same with the TypeScript definition files. Let me know if I need to adjust something.