### PR TITLE
fix: associate Tooltip to exported Tooltip type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -76,7 +76,7 @@ import TableHeader from './TableHeader';
 import Toast from './Toast';
 import ToastBody from './ToastBody';
 import ToastHeader from './ToastHeader';
-import Tooltip from './ToastHeader';
+import Tooltip from './Tooltip';
 import UncontrolledAlert from './Alert';
 import UncontrolledButtonDropdown from './Dropdown';
 import UncontrolledCollapse from './Collapse';


### PR DESCRIPTION
This fixes type definitions for Tooltip.