### PR TITLE
Fix type definitions for ButtonDropdown

### DIFF
--- a/src/ButtonDropdown.d.ts
+++ b/src/ButtonDropdown.d.ts
@@ -1,9 +1,9 @@
 import { DropdownProps } from './Dropdown';
 import { SvelteComponentTyped } from 'svelte';
 
-export interface ButtonDropdownProps extends Omit<IDropdownProps, 'group'> {}
+export interface ButtonDropdownProps extends Omit<DropdownProps, 'group'> {}
 
-export default class Modal extends ButtonDropdown<
+export default class ButtonDropdown extends SvelteComponentTyped<
   ButtonDropdownProps,
   {},
   {


### PR DESCRIPTION
Fixes this error from the TS language server when using `ButtonDropdown`:

```
'ButtonDropdown' cannot be used as a JSX component.
  Its instance type 'Modal' is not a valid JSX element.
    Property '$$prop_def' is missing in type 'Modal' but required in type 'ElementClass'.ts(2786)
```
