### PR TITLE
-Added hideOnOutClick

### DIFF
--- a/src/Popover.d.ts
+++ b/src/Popover.d.ts
@@ -10,7 +10,7 @@ export interface PopoverProps
   container?: ContainerType;
   dismissible?: boolean;
   isOpen?: boolean;
-  hideOnOutClick: boolean;
+  hideOnOutClick?: boolean;
   placement?: PopoverPlacement;
   target: string;
   title?: string;

--- a/src/Popover.d.ts
+++ b/src/Popover.d.ts
@@ -10,6 +10,7 @@ export interface PopoverProps
   container?: ContainerType;
   dismissible?: boolean;
   isOpen?: boolean;
+  hideOnOutClick: boolean;
   placement?: PopoverPlacement;
   target: string;
   title?: string;

--- a/src/Popover.svelte
+++ b/src/Popover.svelte
@@ -12,6 +12,7 @@
   export let container = undefined;
   export let dismissible = false;
   export let isOpen = false;
+  export let hideOnOutClick = false;
   export let placement = 'top';
   export let target = '';
   export let title = '';
@@ -109,9 +110,14 @@
     isOpen ? 'show' : false
   );
 
+  const handleClick = (event) => {
+    if (isOpen && hideOnOutClick && !popoverEl.contains(event.target))
+      isOpen = false;
+  };
   $: outer = container === 'inline' ? InlineContainer : Portal;
 </script>
 
+<svelte:window on:mousedown={handleClick} />
 {#if isOpen}
   <svelte:component this={outer}>
     <div


### PR DESCRIPTION
Hides Popover on click outside of itself
Useful when bind:isOpen to make Popover interactive but makes it act like Bootstraps original Popover's behaviour

usage:

`<Popover
                bind:isOpen={isPopoverOpen}
                hideOnOutClick={true}
              > ...
</Popover>`