### PR TITLE
Fix click handling in Modal

### DIFF
--- a/src/Modal.svelte
+++ b/src/Modal.svelte
@@ -154,7 +154,6 @@
 
   function handleBackdropClick(e) {
     if (e.target === _mouseDownElement) {
-      e.stopPropagation();
       if (!isOpen || !backdrop) {
         return;
       }
@@ -166,6 +165,7 @@
         e.target === backdropElem &&
         toggle
       ) {
+        e.stopPropagation();
         toggle(e);
       }
     }


### PR DESCRIPTION
When using sveltestrap w/ SvelteKit, stopping propagation of the click event in modals breaks SvelteKit's handling of that click event, and so you get a full browser navigation, rather than a navigation within the single-page web app.

To repro this, build a modal with a link in the modal body.

What we actually want here is to stop propagation of the event only if it's a click on the backdrop that we handle.