### PR TITLE
fix: disabled button with href attribute

### DIFF
--- a/src/Button.svelte
+++ b/src/Button.svelte
@@ -27,7 +27,7 @@
     block ? 'd-block w-100' : false,
     {
       active,
-      'btn-close-white': close && white,
+      'btn-close-white': close && white
     }
   );
 
@@ -38,12 +38,12 @@
   <a
     {...$$restProps}
     class={classes}
-    {disabled}
     bind:this={inner}
     on:click
     {href}
     aria-label={ariaLabel || defaultAriaLabel}
     {style}
+    class:disabled
   >
     {#if children}
       {children}
@@ -71,3 +71,10 @@
     </slot>
   </button>
 {/if}
+
+<style>
+  a.disabled {
+    pointer-events: none;
+    cursor: default;
+  }
+</style>

--- a/stories/button/Colors.svelte
+++ b/stories/button/Colors.svelte
@@ -17,3 +17,7 @@
     <Button {color}>{color}</Button>
   </div>
 {/each}
+
+<div>
+  <Button href="/" color="primary">button with href</Button>
+</div>

--- a/stories/button/Disabled.svelte
+++ b/stories/button/Disabled.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import type { ButtonColor } from 'src/Button';
   import { Button } from 'sveltestrap';
 
-  const colors = [
+  const colors: ButtonColor[] = [
     'primary',
     'secondary',
     'success',
@@ -18,3 +19,7 @@
     <Button disabled {color}>{color}</Button>
   </div>
 {/each}
+
+<div>
+  <Button href="/" disabled color="primary">button with href</Button>
+</div>

--- a/stories/button/Outline.svelte
+++ b/stories/button/Outline.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import type { ButtonColor } from 'src/Button';
   import { Button } from 'sveltestrap';
 
-  const colors = [
+  const colors: ButtonColor[] = [
     'primary',
     'secondary',
     'success',
@@ -18,3 +19,7 @@
     <Button outline {color}>{color}</Button>
   </div>
 {/each}
+
+<div>
+  <Button href="/" outline color="primary">button with href</Button>
+</div>


### PR DESCRIPTION
fixes #405
used [this](https://stackoverflow.com/questions/13955667/disabled-href-tag/13955695) as solution.
also, added type to the `colors: ButtonColor[]` array to remove vscode type warnings.