### PR TITLE
Fixing Collapse.svelte when used within a navbar

### DIFF
--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { createEventDispatcher, onMount } from 'svelte';
-  import { collapseIn, collapseOut } from './transitions';
+  import {createEventDispatcher, onMount} from 'svelte';
+  import {collapseIn, collapseOut} from './transitions';
   import classnames from './utils';
   import toggle from './toggle';
 
@@ -8,17 +8,38 @@
 
   export let isOpen = false;
   let className = '';
-  export { className as class };
+  export {className as class};
   export let horizontal = false;
   export let navbar = false;
-  export let onEntering = () => dispatch('opening');
-  export let onEntered = () => dispatch('open');
-  export let onExiting = () => dispatch('closing');
-  export let onExited = () => dispatch('close');
+  export let onEntering = () =>
+  {
+    transitioning = true;
+    dispatch('opening')
+  };
+  export let onEntered = () =>
+  {
+    transitioning = false;
+    dispatch('open')
+  };
+  export let onExiting = () =>
+  {
+    transitioning = true;
+    dispatch('closing')
+  };
+  export let onExited = () =>
+  {
+    transitioning = false;
+    dispatch('close')
+  };
   export let toggler = null;
+  let transitioning = false;
 
-  onMount(() => toggle(toggler, (e) => {
-    isOpen = !isOpen;
+  onMount(() => toggle(toggler, (e) =>
+  {
+    if(!transitioning)
+    {
+      isOpen = !isOpen;
+    }
     e.preventDefault();
   }));
 
@@ -28,25 +49,28 @@
     'd-none': !isOpen
   });
 
-  function notify() {
+  function notify()
+  {
     dispatch('update', isOpen);
   }
 </script>
 
+{#key isOpen}
 <div
-  style={navbar ? undefined : 'overflow: hidden;'}
-  {...$$restProps}
-  class={classes}
-  in:collapseIn={{ horizontal }}
-  out:collapseOut|local={{ horizontal }}
-  on:introstart
-  on:introend
-  on:outrostart
-  on:outroend
-  on:introstart={onEntering}
-  on:introend={onEntered}
-  on:outrostart={onExiting}
-  on:outroend={onExited}
+    style={navbar ? undefined : 'overflow: hidden;'}
+    {...$$restProps}
+    class={classes}
+    in:collapseIn={{ horizontal }}
+    out:collapseOut|local={{ horizontal }}
+    on:introstart
+    on:introend
+    on:outrostart
+    on:outroend
+    on:introstart={onEntering}
+    on:introend={onEntered}
+    on:outrostart={onExiting}
+    on:outroend={onExited}
 >
   <slot />
 </div>
+  {/key}

--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -15,7 +15,6 @@
   export let onEntered = () => dispatch('open');
   export let onExiting = () => dispatch('closing');
   export let onExited = () => dispatch('close');
-  export let expand = false;
   export let toggler = null;
 
   onMount(() => toggle(toggler, (e) => {
@@ -25,55 +24,29 @@
 
   $: classes = classnames(className, {
     'collapse-horizontal': horizontal,
-    'navbar-collapse': navbar
+    'navbar-collapse': navbar,
+    'd-none': !isOpen
   });
-
-  let windowWidth = 0;
-  let _wasMaximized = false;
-
-  // TODO wrong to hardcode these here - come from Bootstrap CSS only
-  const minWidth = {};
-  minWidth['xs'] = 0;
-  minWidth['sm'] = 576;
-  minWidth['md'] = 768;
-  minWidth['lg'] = 992;
-  minWidth['xl'] = 1200;
 
   function notify() {
     dispatch('update', isOpen);
   }
-
-  $: if (navbar && expand) {
-    if (windowWidth >= minWidth[expand] && !isOpen) {
-      isOpen = true;
-      _wasMaximized = true;
-      notify();
-    } else if (windowWidth < minWidth[expand] && _wasMaximized) {
-      isOpen = false;
-      _wasMaximized = false;
-      notify();
-    }
-  }
 </script>
 
-<svelte:window bind:innerWidth={windowWidth} />
-
-{#if isOpen}
-  <div
-    style={navbar ? undefined : 'overflow: hidden;'}
-    {...$$restProps}
-    class={classes}
-    in:collapseIn={{ horizontal }}
-    out:collapseOut|local={{ horizontal }}
-    on:introstart
-    on:introend
-    on:outrostart
-    on:outroend
-    on:introstart={onEntering}
-    on:introend={onEntered}
-    on:outrostart={onExiting}
-    on:outroend={onExited}
-  >
-    <slot />
-  </div>
-{/if}
+<div
+  style={navbar ? undefined : 'overflow: hidden;'}
+  {...$$restProps}
+  class={classes}
+  in:collapseIn={{ horizontal }}
+  out:collapseOut|local={{ horizontal }}
+  on:introstart
+  on:introend
+  on:outrostart
+  on:outroend
+  on:introstart={onEntering}
+  on:introend={onEntered}
+  on:outrostart={onExiting}
+  on:outroend={onExited}
+>
+  <slot />
+</div>

--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -18,10 +18,8 @@
   export let toggler = null;
   let transitioning = false;
 
-  onMount(() => toggle(toggler, (e) =>
-  {
-    if(!transitioning)
-    {
+  onMount(() => toggle(toggler, (e) => {
+    if (!transitioning) {
       isOpen = !isOpen;
     }
   }));
@@ -32,32 +30,27 @@
     'd-none': !isOpen
   });
 
-  function notify()
-  {
+  function notify() {
     dispatch('update', isOpen);
   }
   
 
-  function _onEntering(event)
-  {
+  function _onEntering(event) {
     transitioning = true;
     onEntering(event);
   }
   
-  function _onEntered(event)
-  {
+  function _onEntered(event) {
     transitioning = false;
     onEntered(event);
   }
   
-  function _onExiting(event)
-  {
+  function _onExiting(event) {
     transitioning = true;
     onExiting(event);
   }
   
-  function _onExited(event)
-  {
+  function _onExited(event) {
     transitioning = false;
     onExited(event);
   }

--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -1,6 +1,6 @@
 <script>
-  import {createEventDispatcher, onMount} from 'svelte';
-  import {collapseIn, collapseOut} from './transitions';
+  import { createEventDispatcher, onMount } from 'svelte';
+  import { collapseIn, collapseOut } from './transitions';
   import classnames from './utils';
   import toggle from './toggle';
 
@@ -8,29 +8,13 @@
 
   export let isOpen = false;
   let className = '';
-  export {className as class};
+  export { className as class };
   export let horizontal = false;
   export let navbar = false;
-  export let onEntering = () =>
-  {
-    transitioning = true;
-    dispatch('opening')
-  };
-  export let onEntered = () =>
-  {
-    transitioning = false;
-    dispatch('open')
-  };
-  export let onExiting = () =>
-  {
-    transitioning = true;
-    dispatch('closing')
-  };
-  export let onExited = () =>
-  {
-    transitioning = false;
-    dispatch('close')
-  };
+  export let onEntering = () => dispatch('opening');
+  export let onEntered = () => dispatch('open');
+  export let onExiting = () => dispatch('closing');
+  export let onExited = () => dispatch('close');
   export let toggler = null;
   let transitioning = false;
 
@@ -52,6 +36,31 @@
   {
     dispatch('update', isOpen);
   }
+  
+
+  function _onEntering(event)
+  {
+    transitioning = true;
+    onEntering(event);
+  }
+  
+  function _onEntered(event)
+  {
+    transitioning = false;
+    onEntered(event);
+  }
+  
+  function _onExiting(event)
+  {
+    transitioning = true;
+    onExiting(event);
+  }
+  
+  function _onExited(event)
+  {
+    transitioning = false;
+    onExited(event);
+  }
 </script>
 
 {#key isOpen}
@@ -65,10 +74,10 @@
       on:introend
       on:outrostart
       on:outroend
-      on:introstart={onEntering}
-      on:introend={onEntered}
-      on:outrostart={onExiting}
-      on:outroend={onExited}
+      on:introstart={_onEntering}
+      on:introend={_onEntered}
+      on:outrostart={_onExiting}
+      on:outroend={_onExited}
   >
     <slot />
   </div>

--- a/src/Collapse.svelte
+++ b/src/Collapse.svelte
@@ -40,7 +40,6 @@
     {
       isOpen = !isOpen;
     }
-    e.preventDefault();
   }));
 
   $: classes = classnames(className, {
@@ -56,21 +55,21 @@
 </script>
 
 {#key isOpen}
-<div
-    style={navbar ? undefined : 'overflow: hidden;'}
-    {...$$restProps}
-    class={classes}
-    in:collapseIn={{ horizontal }}
-    out:collapseOut|local={{ horizontal }}
-    on:introstart
-    on:introend
-    on:outrostart
-    on:outroend
-    on:introstart={onEntering}
-    on:introend={onEntered}
-    on:outrostart={onExiting}
-    on:outroend={onExited}
->
-  <slot />
-</div>
-  {/key}
+  <div
+      style={navbar ? undefined : 'overflow: hidden;'}
+      {...$$restProps}
+      class={classes}
+      in:collapseIn={{ horizontal }}
+      out:collapseOut|local={{ horizontal }}
+      on:introstart
+      on:introend
+      on:outrostart
+      on:outroend
+      on:introstart={onEntering}
+      on:introend={onEntered}
+      on:outrostart={onExiting}
+      on:outroend={onExited}
+  >
+    <slot />
+  </div>
+{/key}


### PR DESCRIPTION
Hi there

I came across some issues using collapse within a navbar, with this following issues should be fixed:
- Animation triggers when opening a page using a navbar with a collapse
- Animation triggers when the screen gets smaller and the collapse starts to hide (and other way around)
- Toggler button for collapse is not being focused when clicked
- Toggler button can be toggled mid animation (not the case with bootstrap's js)

The collapse no longer removes and re-adds it's content to the dom, instead it uses bootstrap's "d-none" class to hide it. I do that so bootstrap's "navbar-expand-xx" class can show the collapse content again, when a certain screen size is reached. We no longer need to check for that and it won't animate for a second.

Example code:
```
<Navbar expand="md">
  <NavbarBrand href="#">Test</NavbarBrand>
  <NavbarToggler id="exampleNavToggler"/>
  <Collapse toggler="#exampleNavToggler" navbar>
    <Nav class="ms-auto" navbar>
      <NavItem>
        <NavLink href="#">Test</NavLink>
      </NavItem>
    </Nav>
  </Collapse>
</Navbar>
```

Unfortunately I couldn't find a solution how to prevent isOpen from changing, when it's accessed directly.