### PR TITLE
Swap order of bindings and event listeners

### DIFF
--- a/src/FormCheck.svelte
+++ b/src/FormCheck.svelte
@@ -37,12 +37,12 @@
       class={inputClasses}
       id={idFor}
       type="radio"
+      bind:group
+      bind:this={inner}
       on:blur
       on:change
       on:focus
       on:input
-      bind:group
-      bind:this={inner}
       {disabled}
       {name}
       {value}
@@ -53,12 +53,12 @@
       class={inputClasses}
       id={idFor}
       type="checkbox"
+      bind:checked
+      bind:this={inner}
       on:blur
       on:change
       on:focus
       on:input
-      bind:checked
-      bind:this={inner}
       {disabled}
       {name}
       {value}
@@ -69,12 +69,12 @@
       class={inputClasses}
       id={idFor}
       type="checkbox"
+      bind:checked
+      bind:this={inner}
       on:blur
       on:change
       on:focus
       on:input
-      bind:checked
-      bind:this={inner}
       {disabled}
       {name}
       {value}

--- a/src/Input.svelte
+++ b/src/Input.svelte
@@ -96,6 +96,8 @@
       {...$$restProps}
       class={classes}
       type="text"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -103,8 +105,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -116,6 +116,8 @@
       {...$$restProps}
       class={classes}
       type="password"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -123,8 +125,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -136,6 +136,8 @@
       {...$$restProps}
       class={classes}
       type="color"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -143,8 +145,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -155,6 +155,8 @@
       {...$$restProps}
       class={classes}
       type="email"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -162,8 +164,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {multiple}
       {name}
@@ -176,6 +176,9 @@
       {...$$restProps}
       class={classes}
       type="file"
+      bind:files
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -183,9 +186,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:files
-      bind:value
-      bind:this={inner}
       {disabled}
       {invalid}
       {multiple}
@@ -200,6 +200,10 @@
       class={className}
       size={bsSize}
       {type}
+      bind:checked
+      bind:inner
+      bind:group
+      bind:value
       on:blur
       on:change
       on:focus
@@ -207,10 +211,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:checked
-      bind:inner
-      bind:group
-      bind:value
       {disabled}
       {invalid}
       {label}
@@ -224,6 +224,8 @@
       {...$$restProps}
       class={classes}
       type="url"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -231,8 +233,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -244,6 +244,8 @@
       {...$$restProps}
       class={classes}
       type="number"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -251,8 +253,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {readonly}
       {name}
       {disabled}
@@ -263,6 +263,8 @@
       {...$$restProps}
       class={classes}
       type="date"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -270,8 +272,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -282,6 +282,8 @@
       {...$$restProps}
       class={classes}
       type="time"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -289,8 +291,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -300,6 +300,8 @@
     <input
       {...$$restProps}
       type="datetime"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -307,8 +309,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {readonly}
       class={classes}
       {name}
@@ -320,6 +320,8 @@
       {...$$restProps}
       class={classes}
       type="datetime-local"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -327,8 +329,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -339,6 +339,8 @@
       {...$$restProps}
       class={classes}
       type="month"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -346,8 +348,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -357,6 +357,8 @@
     <input
       {...$$restProps}
       type="color"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -364,8 +366,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {readonly}
       class={classes}
       {name}
@@ -376,6 +376,8 @@
     <input
       {...$$restProps}
       type="range"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -383,8 +385,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {readonly}
       class={classes}
       {name}
@@ -396,6 +396,8 @@
       {...$$restProps}
       class={classes}
       type="search"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -403,8 +405,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -416,6 +416,8 @@
       {...$$restProps}
       class={classes}
       type="tel"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -423,8 +425,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -436,6 +436,8 @@
       {...$$restProps}
       class={classes}
       type="week"
+      bind:value
+      bind:this={inner}
       on:blur
       on:change
       on:focus
@@ -443,8 +445,6 @@
       on:keydown
       on:keypress
       on:keyup
-      bind:value
-      bind:this={inner}
       {disabled}
       {name}
       {placeholder}
@@ -473,6 +473,8 @@
   <textarea
     {...$$restProps}
     class={classes}
+    bind:value
+    bind:this={inner}
     on:blur
     on:change
     on:focus
@@ -480,8 +482,6 @@
     on:keydown
     on:keypress
     on:keyup
-    bind:value
-    bind:this={inner}
     {disabled}
     {name}
     {placeholder}
@@ -491,12 +491,12 @@
   <select
     {...$$restProps}
     class={classes}
+    bind:value
+    bind:this={inner}
     on:blur
     on:change
     on:focus
     on:input
-    bind:value
-    bind:this={inner}
     {name}
     {disabled}
     {readonly}

--- a/src/__test__/Input.spec.js
+++ b/src/__test__/Input.spec.js
@@ -1,5 +1,6 @@
 import Input from '../Input.svelte';
-import { render, cleanup } from '@testing-library/svelte';
+import {render, cleanup, fireEvent} from '@testing-library/svelte';
+import InputTest from './InputTest.spec.svelte'
 
 const renderInput = (props) => {
   const { container } = render(Input, { props });
@@ -134,5 +135,15 @@ describe('Input', () => {
     const container = renderInput();
     expect(container.querySelector('.invalid-feedback')).toBeNull();
     expect(container.querySelector('.valid-feedback')).toBeNull();
+  });
+
+  test('should have correct bound value in on:change listener', async () => {
+    const {getByTestId} = render(InputTest);
+    expect(getByTestId('checkbox').checked).toBe(false)
+    await fireEvent.click(getByTestId('checkbox'));
+    expect(getByTestId('checkbox').checked).toBe(true)
+
+    expect(getByTestId('reactiveAccountEnabled').innerHTML).toEqual("true");
+    expect(getByTestId('onChangeAccountEnabled').innerHTML).toEqual("true");
   });
 });

--- a/src/__test__/InputTest.spec.svelte
+++ b/src/__test__/InputTest.spec.svelte
@@ -1,0 +1,23 @@
+<script>
+    import Input from "../Input.svelte";
+
+    let user = {
+        accountEnabled: false
+    }
+
+    let onChangeAccountEnabled = false
+
+    const onChange = () => {
+        onChangeAccountEnabled = user.accountEnabled
+    }
+</script>
+
+<Input data-testid="checkbox" type="checkbox" bind:checked={user.accountEnabled} on:change={onChange} />
+
+<p data-testid="reactiveAccountEnabled">
+    {user.accountEnabled}
+</p>
+
+<p data-testid="onChangeAccountEnabled">
+    {onChangeAccountEnabled}
+</p>


### PR DESCRIPTION
## Summary 

This PR swaps the attributes for binds and events in the `Input` and `FormCheck` components.

## The Problem

As it turns out, the order of these attributes actually matters in the `input`, `select` etc components. If the event listener is listed before the bind, the bound value will not be up to date when the event listener is called.

E.g.

```svelte
<input on:change={xxx} bind:value={yyy} />
<input bind:value={yyy} on:change={xxx} />
```

Function differently, in the first example, `yyy` will not be the correct value in the event listener.

## The Solution

Considering there is currently no way to specify the order of attributes on sub-components, I think it makes more sense to use a sensible default. 