### PR TITLE
Remove unused 'mb-3' from FormGroup

### DIFF
--- a/src/FormGroup.svelte
+++ b/src/FormGroup.svelte
@@ -11,7 +11,7 @@
   export let row = false;
   export let tag = null;
 
-  $: classes = classnames(className, 'mb-3', {
+  $: classes = classnames(className, {
     row,
     'form-check': check,
     'form-check-inline': check && inline,


### PR DESCRIPTION
The **'mb-3'** class in **FormGroup** is causing some problems when floating **FormGroup** is used with **InputGroup**.
Example: [Svelte REPL](https://svelte.dev/repl/a816c75dc8494f8a94f5a2cbbc1a8ef1?version=3.46.3)
This is described in #458.