### PR TITLE
fix carousel control prev btn disable warp bug

### DIFF
--- a/src/CarouselControl.svelte
+++ b/src/CarouselControl.svelte
@@ -27,7 +27,7 @@
   function clickHandler() {
     const endOrBeginning =
       (direction === 'next' && activeIndex + 1 > items.length - 1) ||
-      (direction === 'previous' && activeIndex - 1 < 0);
+      (direction === 'prev' && activeIndex - 1 < 0);
 
     if (!wrap && endOrBeginning) {
       return;


### PR DESCRIPTION
I set a Carousel compont pervious button property: wrap={false} but it not work. And I find this spelling error in source code😊
Please kindly review and merge this fix.