### PR TITLE
Update Bootstrap colors for 5.3

### DIFF
--- a/src/FormText.svelte
+++ b/src/FormText.svelte
@@ -4,7 +4,7 @@
   let className = '';
   export { className as class };
   export let inline = false;
-  export let color = 'muted';
+  export let color = undefined;
 
   $: classes = classnames(
     className,

--- a/src/__test__/FormText.spec.js
+++ b/src/__test__/FormText.spec.js
@@ -8,7 +8,6 @@ describe('FormText', () => {
     const { container } = render(FormText);
     const formtext = container.querySelector('.form-text');
     expect(formtext.className).toContain('form-text');
-    expect(formtext.className).toContain('text-muted');
   });
 
   test('should render custom color', () => {

--- a/src/shared.d.ts
+++ b/src/shared.d.ts
@@ -15,17 +15,55 @@ export declare type Color =
   | 'light'
   | 'dark';
 
-declare type BackgroundOnlyColor = 'white' | 'transparent';
-
-declare type TextOnlyColor =
+export declare type BackgroundColor =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'light'
+  | 'dark'
+  | 'primary-subtle'
+  | 'secondary-subtle'
+  | 'success-subtle'
+  | 'danger-subtle'
+  | 'warning-subtle'
+  | 'info-subtle'
+  | 'light-subtle'
+  | 'dark-subtle'
+  | 'black'
+  | 'white'
+  | 'transparent'
   | 'body'
-  | 'muted'
+  | 'body-secondary'
+  | 'body-tertiary';
+
+export declare type TextColor =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'light'
+  | 'dark'
+  | 'primary-emphasis'
+  | 'secondary-emphasis'
+  | 'success-emphasis'
+  | 'danger-emphasis'
+  | 'warning-emphasis'
+  | 'info-emphasis'
+  | 'light-emphasis'
+  | 'dark-emphasis'
+  | 'body'
+  | 'body-emphasis'
+  | 'body-secondary'
+  | 'body-tertiary'
+  | 'black'
   | 'white'
   | 'black-50'
   | 'white-50';
-
-export declare type BackgroundColor = Color | BackgroundOnlyColor;
-export declare type TextColor = Color | TextOnlyColor;
 
 export declare type Direction =
   | 'up'

--- a/stories/Example.svelte
+++ b/stories/Example.svelte
@@ -13,7 +13,7 @@
   {/if}
   <slot name="info" />
   <div class="border p-3">
-    <h6 class="text-muted">EXAMPLE</h6>
+    <h6 class="text-body-tertiary">EXAMPLE</h6>
     <Row>
       <Col md={stacked ? 12 : 5}>
         <slot />

--- a/stories/badge/Colors.svelte
+++ b/stories/badge/Colors.svelte
@@ -9,7 +9,15 @@
     'warning',
     'info',
     'light',
-    'dark'
+    'dark',
+    'primary-subtle',
+    'secondary-subtle',
+    'success-subtle',
+    'danger-subtle',
+    'warning-subtle',
+    'info-subtle',
+    'light-subtle',
+    'dark-subtle'
   ];
 </script>
 

--- a/stories/icon/Index.svelte
+++ b/stories/icon/Index.svelte
@@ -1890,7 +1890,7 @@
         <div class="p-3 py-4 mb-2 bg-light text-center rounded">
           <Icon {name} />
         </div>
-        <div class="small text-muted text-decoration-none text-center">
+        <div class="small text-decoration-none text-center">
           {name}
         </div>
       </div>

--- a/stories/input/Sample.svelte
+++ b/stories/input/Sample.svelte
@@ -128,7 +128,7 @@
   <FormGroup>
     <Label for="exampleFile">File</Label>
     <Input type="file" name="file" id="exampleFile" />
-    <FormText color="muted">
+    <FormText>
       This is some placeholder block-level help text for the above input. It's a
       bit lighter and easily wraps to a new line.
     </FormText>

--- a/stories/navbar/Colors.svelte
+++ b/stories/navbar/Colors.svelte
@@ -9,7 +9,15 @@
     'warning',
     'info',
     'light',
-    'dark'
+    'dark',
+    'primary-subtle',
+    'secondary-subtle',
+    'success-subtle',
+    'danger-subtle',
+    'warning-subtle',
+    'info-subtle',
+    'light-subtle',
+    'dark-subtle'
   ];
 </script>
 

--- a/stories/progress/Colors.svelte
+++ b/stories/progress/Colors.svelte
@@ -1,9 +1,28 @@
 <script lang="ts">
   import { Progress } from 'sveltestrap';
+
+  const colors = [
+    'primary',
+    'secondary',
+    'success',
+    'danger',
+    'warning',
+    'info',
+    'light',
+    'dark',
+    'primary-subtle',
+    'secondary-subtle',
+    'success-subtle',
+    'danger-subtle',
+    'warning-subtle',
+    'info-subtle',
+    'light-subtle',
+    'dark-subtle'
+  ];
 </script>
 
-<Progress value={2 * 5} />
-<Progress color="success" value={25} />
-<Progress color="info" value={50} />
-<Progress color="warning" value={75} />
-<Progress color="danger" value={100} />
+{#each colors as color, i}
+  <Progress {color} value={Math.random() * 50 + 50} class="mb-2">
+    {color}
+  </Progress>
+{/each}

--- a/stories/spinner/Colors.svelte
+++ b/stories/spinner/Colors.svelte
@@ -13,5 +13,5 @@
 </script>
 
 {#each colors as color}
-  <Spinner {color} />
+  <Spinner {color} class="m-1" />
 {/each}

--- a/stories/spinner/Type.svelte
+++ b/stories/spinner/Type.svelte
@@ -14,12 +14,12 @@
 
 <div>
   {#each colors as color}
-    <Spinner {color} type="border" />
+    <Spinner {color} type="border" class="m-1" />
   {/each}
 </div>
 
 <div>
   {#each colors as color}
-    <Spinner {color} type="grow" />
+    <Spinner {color} type="grow" class="m-1" />
   {/each}
 </div>

--- a/stories/styles/Index.svelte
+++ b/stories/styles/Index.svelte
@@ -28,10 +28,10 @@
 
 <Example title="Theme" source={themeSource}>
   <p slot="info">
-    The optional theme attribute allows you set the color mode for the included styles.
-    The 'light' and 'dark' values explicitly sets the theme, and 'auto' matches the user's system preference.
-    When not specified, the default theme is light.
-    See Bootstrap's 
+    The optional theme attribute allows you set the color mode for the included
+    styles. The 'light' and 'dark' values explicitly sets the theme, and 'auto'
+    matches the user's system preference. When not specified, the default theme
+    is light. See Bootstrap's
     <a
       href="https://getbootstrap.com/docs/5.3/customize/color-modes/"
       rel="noreferrer"

--- a/stories/styles/Theme.svelte
+++ b/stories/styles/Theme.svelte
@@ -1,7 +1,7 @@
-<script lang="ts">
+<script>
   import { Button, Icon, Styles } from 'sveltestrap';
 
-  let theme = 'auto';
+  let theme = 'light';
 </script>
 
 <Styles {theme} />
@@ -30,4 +30,3 @@
 >
   auto <Icon name="circle-half" />
 </Button>
-


### PR DESCRIPTION
- Remove incorrect 'muted' default color for FormText.
- Add *-subtle & *-emphasis colors to TypeScript types.
- Add new *-subtle colors for Badge, Navbar, Progress stories.
- Improve Progress colors story
- Remove deprecated 'muted' color
- Improve Spinner story margins
- Change Styles story to default to light theme -