### PR TITLE
chore(exports): add exports to package.json for svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,11 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8"
   },
-  "browserslist": "last 2 versions"
+  "browserslist": "last 2 versions",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./src/index.js"
+    }
+  }
 }


### PR DESCRIPTION
This resolves the issue. 

> [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

sveltestrap@5.11.2